### PR TITLE
Happly upgrade +  fix

### DIFF
--- a/include/geometrycentral/ply_wrapper.h
+++ b/include/geometrycentral/ply_wrapper.h
@@ -78,7 +78,7 @@ VertexData<T> PlyHalfedgeMeshData::getVertexProperty(std::string propertyName) {
     getMesh();
   }
 
-  std::vector<T> rawData = plyData->getProperty<T>(vertexName, propertyName);
+  std::vector<T> rawData = plyData->getElement(vertexName).getProperty<T>(propertyName);
 
   if (rawData.size() != mesh->nVertices()) {
     throw std::runtime_error("Property " + propertyName + " does not have size equal to number of vertices");
@@ -99,7 +99,7 @@ FaceData<T> PlyHalfedgeMeshData::getFaceProperty(std::string propertyName) {
     getMesh();
   }
 
-  std::vector<T> rawData = plyData->getProperty<T>(faceName, propertyName);
+  std::vector<T> rawData = plyData->getElement(faceName).getProperty<T>(propertyName);
 
   if (rawData.size() != mesh->nVertices()) {
     throw std::runtime_error("Property " + propertyName + " does not have size equal to number of vertices");


### PR DESCRIPTION
This PR upgrades happly's version of geometry-central to the current master (with a quick fix on the ply_wrapper).

The previous version happly generates build issues (virtual destructor one) that have been fixed in the master (which also makes polyscope impossible to build on mac with the latest clang). 