### PR TITLE
Updated eigenvalue solver for complex matrices

### DIFF
--- a/include/geometrycentral/numerical/linear_solvers.h
+++ b/include/geometrycentral/numerical/linear_solvers.h
@@ -24,6 +24,10 @@ Vector<T> smallestEigenvectorPositiveDefinite(SparseMatrix<T>& energyMatrix, Spa
 template <typename T>
 std::vector<Vector<T>> smallestKEigenvectorsPositiveDefinite(SparseMatrix<T>& energyMatrix, SparseMatrix<T>& massMatrix,
                                                              size_t kEigenvalues, size_t nIterations = 50);
+template <typename T>
+std::vector<Vector<T>> smallestKEigenvectorsPositiveDefiniteTol(SparseMatrix<T>& energyMatrix,
+                                                                SparseMatrix<T>& massMatrix, size_t kEigenvalues,
+                                                                double tol = 1e-8);
 
 // Returns smallest (positive-eigenvalued) nontirivial eigenvector
 template <typename T>
@@ -33,6 +37,10 @@ Vector<T> smallestEigenvectorSquare(SparseMatrix<T>& energyMatrix, SparseMatrix<
 // Mass matrix must be positive definite
 template <typename T>
 Vector<T> largestEigenvector(SparseMatrix<T>& energyMatrix, SparseMatrix<T>& massMatrix, size_t nIterations = 50);
+
+// Measure L2 residual
+template <typename T>
+double eigenvectorResidual(const SparseMatrix<T>& energyMatrix, const SparseMatrix<T>& massMatrix, const Vector<T>& v);
 
 // Quick and easy solvers which do not retain factorization
 template <typename T>
@@ -119,7 +127,7 @@ public:
   Vector<T> solve(const Vector<T>& rhs) override;
 
 protected:
-// Implementation-specific quantities
+  // Implementation-specific quantities
   std::unique_ptr<SquareSolverInternals<T>> internals;
 };
 

--- a/include/geometrycentral/surface/halfedge_containers.h
+++ b/include/geometrycentral/surface/halfedge_containers.h
@@ -19,7 +19,7 @@ namespace surface {
 // T is the data type that it holds (eg double)
 template <typename E, typename T>
 class MeshData {
-private:
+protected:
   // The mesh that this data is defined on
   HalfedgeMesh* mesh = nullptr;
 

--- a/src/numerical/eigenproblem_solvers.cpp
+++ b/src/numerical/eigenproblem_solvers.cpp
@@ -12,12 +12,12 @@ namespace geometrycentral {
 namespace {
 
 template <typename T>
-double norm(Vector<T>& x, SparseMatrix<T>& massMatrix) {
+double norm(const Vector<T>& x, const SparseMatrix<T>& massMatrix) {
   return std::sqrt(std::abs(x.dot(massMatrix * x)));
 }
-template double norm(Vector<double>& x, SparseMatrix<double>& massMatrix);
-template double norm(Vector<float>& x, SparseMatrix<float>& massMatrix);
-template double norm(Vector<std::complex<double>>& x, SparseMatrix<std::complex<double>>& massMatrix);
+template double norm(const Vector<double>& x, const SparseMatrix<double>& massMatrix);
+template double norm(const Vector<float>& x, const SparseMatrix<float>& massMatrix);
+template double norm(const Vector<std::complex<double>>& x, const SparseMatrix<std::complex<double>>& massMatrix);
 
 template <typename T>
 void normalize(Vector<T>& x, SparseMatrix<T>& massMatrix) {
@@ -68,7 +68,7 @@ std::vector<Vector<T>> smallestKEigenvectorsPositiveDefinite(SparseMatrix<T>& en
   auto projectOutPreviousVectors = [&](Vector<T>& x) {
     for (Vector<T>& v : res) {
       T proj = ((v.dot(massMatrix * x)));
-      x -= v * proj;
+      x -= proj * v;
     }
   };
 
@@ -86,6 +86,46 @@ std::vector<Vector<T>> smallestKEigenvectorsPositiveDefinite(SparseMatrix<T>& en
 
       // Update
       u = x;
+    }
+
+    res.push_back(x);
+  }
+
+  return res;
+}
+
+template <typename T>
+std::vector<Vector<T>> smallestKEigenvectorsPositiveDefiniteTol(SparseMatrix<T>& energyMatrix,
+                                                                SparseMatrix<T>& massMatrix, size_t kEigenvalues,
+                                                                double tol) {
+
+  std::vector<Vector<T>> res;
+
+  size_t N = energyMatrix.rows();
+  PositiveDefiniteSolver<T> solver(energyMatrix);
+
+  auto projectOutPreviousVectors = [&](Vector<T>& x) {
+    for (Vector<T>& v : res) {
+      T proj = ((v.dot(massMatrix * x)));
+      x -= proj * v;
+    }
+  };
+
+  for (size_t kEig = 0; kEig < kEigenvalues; kEig++) {
+    Vector<T> u = Vector<T>::Random(N);
+    projectOutPreviousVectors(u);
+    Vector<T> x = u;
+    double residual = eigenvectorResidual(energyMatrix, massMatrix, x);
+    while (residual > tol) {
+      // Solve
+      solver.solve(x, massMatrix * u);
+
+      projectOutPreviousVectors(x);
+      normalize(x, massMatrix);
+
+      // Update
+      u = x;
+      residual = eigenvectorResidual(energyMatrix, massMatrix, x);
     }
 
     res.push_back(x);
@@ -136,6 +176,14 @@ Vector<T> largestEigenvector(SparseMatrix<T>& energyMatrix, SparseMatrix<T>& mas
   return x;
 }
 
+// Measure L2 residual
+template <typename T>
+double eigenvectorResidual(const SparseMatrix<T>& energyMatrix, const SparseMatrix<T>& massMatrix, const Vector<T>& v) {
+  T candidateEigenvalue = v.dot(energyMatrix * v);
+  Vector<T> err = energyMatrix * v - candidateEigenvalue * massMatrix * v;
+  return norm(err, massMatrix);
+}
+
 // Explicit instantiations
 template Vector<double> smallestEigenvectorPositiveDefinite(SparseMatrix<double>& energyMatrix,
                                                             SparseMatrix<double>& massMatrix, size_t nIterations);
@@ -155,6 +203,18 @@ template std::vector<Vector<std::complex<double>>>
 smallestKEigenvectorsPositiveDefinite(SparseMatrix<std::complex<double>>& energyMatrix,
                                       SparseMatrix<std::complex<double>>& massMatrix, size_t kEigenvalues,
                                       size_t nIterations);
+
+
+template std::vector<Vector<float>> smallestKEigenvectorsPositiveDefiniteTol(SparseMatrix<float>& energyMatrix,
+                                                                             SparseMatrix<float>& massMatrix,
+                                                                             size_t kEigenvalues, double tol);
+template std::vector<Vector<double>> smallestKEigenvectorsPositiveDefiniteTol(SparseMatrix<double>& energyMatrix,
+                                                                              SparseMatrix<double>& massMatrix,
+                                                                              size_t kEigenvalues, double tol);
+template std::vector<Vector<std::complex<double>>>
+smallestKEigenvectorsPositiveDefiniteTol(SparseMatrix<std::complex<double>>& energyMatrix,
+                                         SparseMatrix<std::complex<double>>& massMatrix, size_t kEigenvalues,
+                                         double tol);
 
 template Vector<double> smallestEigenvectorSquare(SparseMatrix<double>& energyMatrix, SparseMatrix<double>& massMatrix,
                                                   size_t nIterations);

--- a/src/numerical/eigenproblem_solvers.cpp
+++ b/src/numerical/eigenproblem_solvers.cpp
@@ -13,7 +13,7 @@ namespace {
 
 template <typename T>
 double norm(Vector<T>& x, SparseMatrix<T>& massMatrix) {
-  return std::sqrt(std::abs((x.transpose() * massMatrix * x)[0]));
+  return std::sqrt(std::abs(x.dot(massMatrix * x)));
 }
 template double norm(Vector<double>& x, SparseMatrix<double>& massMatrix);
 template double norm(Vector<float>& x, SparseMatrix<float>& massMatrix);
@@ -67,7 +67,7 @@ std::vector<Vector<T>> smallestKEigenvectorsPositiveDefinite(SparseMatrix<T>& en
 
   auto projectOutPreviousVectors = [&](Vector<T>& x) {
     for (Vector<T>& v : res) {
-      T proj = (((x.transpose() * massMatrix * v)[0]));
+      T proj = ((v.dot(massMatrix * x)));
       x -= v * proj;
     }
   };


### PR DESCRIPTION
The current k-eigenvalue solver does not work on complex matrices. For complex vectors, `x.transpose() * v` does not give the dot product. I switched to Eigen's `dot` function, which should work in both the real and complex case. Also for projections onto complex vectors, you need to write the dot product in a particular order - `v.dot(x) != x.dot(v)`. So I switched the order of `v` and `x` in the projection.