### PR TITLE
Bugfixes to heat distance and geometry copy

### DIFF
--- a/include/geometrycentral/surface/base_geometry_interface.h
+++ b/include/geometrycentral/surface/base_geometry_interface.h
@@ -31,6 +31,12 @@ public:
   // TODO move this to exist in realizations only
   std::unique_ptr<BaseGeometryInterface> reinterpretTo(HalfedgeMesh& targetMesh);
 
+  // Hide copy and move constructors; users are more likely to use them accidentally than intentionally.
+  // See the explicit copy() function in derived classes.
+  BaseGeometryInterface(const BaseGeometryInterface& other) = delete;
+  BaseGeometryInterface& operator=(const BaseGeometryInterface& other) = delete;
+  BaseGeometryInterface(BaseGeometryInterface&& other) = delete;
+  BaseGeometryInterface& operator=(BaseGeometryInterface&& other) = delete;
 
   // === Quantities
 
@@ -77,6 +83,8 @@ public:
 
 protected:
   // All of the quantities available (subclasses will also add quantities to this list)
+  // Note that this is a vector of non-owning pointers; the quantities are generally value members in the class, so
+  // there is no need to delete these.
   std::vector<DependentQuantity*> quantities;
 
   // === Implementation details for quantities

--- a/include/geometrycentral/surface/edge_length_geometry.h
+++ b/include/geometrycentral/surface/edge_length_geometry.h
@@ -12,6 +12,7 @@ namespace surface {
 class EdgeLengthGeometry : public IntrinsicGeometryInterface {
 
 public:
+  EdgeLengthGeometry(HalfedgeMesh& mesh_);
   EdgeLengthGeometry(HalfedgeMesh& mesh_, EdgeData<double>& inputEdgeLengths);
   virtual ~EdgeLengthGeometry() {}
   

--- a/src/surface/edge_length_geometry.cpp
+++ b/src/surface/edge_length_geometry.cpp
@@ -6,9 +6,21 @@
 namespace geometrycentral {
 namespace surface {
 
+EdgeLengthGeometry::EdgeLengthGeometry(HalfedgeMesh& mesh_)
+    : IntrinsicGeometryInterface(mesh_), inputEdgeLengths(mesh_, 0.)
+{}
 
 EdgeLengthGeometry::EdgeLengthGeometry(HalfedgeMesh& mesh_, EdgeData<double>& inputEdgeLengths_)
     : IntrinsicGeometryInterface(mesh_), inputEdgeLengths(inputEdgeLengths_) {}
+
+std::unique_ptr<EdgeLengthGeometry> EdgeLengthGeometry::copy() { return reinterpretTo(mesh); }
+
+std::unique_ptr<EdgeLengthGeometry> EdgeLengthGeometry::reinterpretTo(HalfedgeMesh& targetMesh) {
+  std::unique_ptr<EdgeLengthGeometry> newGeom(new EdgeLengthGeometry(targetMesh));
+  newGeom->inputEdgeLengths = inputEdgeLengths.reinterpretTo(targetMesh);
+  return newGeom;
+}
+
 
 void EdgeLengthGeometry::computeEdgeLengths() { edgeLengths = inputEdgeLengths; }
 

--- a/src/surface/heat_method_distance.cpp
+++ b/src/surface/heat_method_distance.cpp
@@ -26,8 +26,8 @@ HeatMethodDistanceSolver::HeatMethodDistanceSolver(IntrinsicGeometryInterface& g
   // === Build & factor the linear systems
 
   // Mass matrix
-  geom.requireVertexGalerkinMassMatrix();
-  SparseMatrix<double>& M = geom.vertexGalerkinMassMatrix;
+  geom.requireVertexLumpedMassMatrix();
+  SparseMatrix<double>& M = geom.vertexLumpedMassMatrix;
 
   // Laplacian
   geom.requireCotanLaplacian();
@@ -43,7 +43,7 @@ HeatMethodDistanceSolver::HeatMethodDistanceSolver(IntrinsicGeometryInterface& g
 
   geom.unrequireEdgeLengths();
   geom.unrequireCotanLaplacian();
-  geom.unrequireVertexGalerkinMassMatrix();
+  geom.unrequireVertexLumpedMassMatrix();
 }
 
 

--- a/src/surface/vertex_position_geometry.cpp
+++ b/src/surface/vertex_position_geometry.cpp
@@ -7,11 +7,7 @@ namespace geometrycentral {
 namespace surface {
 
 VertexPositionGeometry::VertexPositionGeometry(HalfedgeMesh& mesh_)
-    // clang-format off
-// formatter is having an outburst here...
-    : EmbeddedGeometryInterface(mesh_), inputVertexPositions(mesh_, Vector3{ 0., 0., 0, })
-// clang-format on
-
+    : EmbeddedGeometryInterface(mesh_), inputVertexPositions(mesh_, Vector3{0., 0., 0})
 {}
 
 VertexPositionGeometry::VertexPositionGeometry(HalfedgeMesh& mesh_, VertexData<Vector3>& inputVertexPositions_)

--- a/test/src/halfedge_geometry_test.cpp
+++ b/test/src/halfedge_geometry_test.cpp
@@ -177,6 +177,34 @@ TEST_F(HalfedgeGeometrySuite, PurgeTestDEC) {
 }
 
 
+// Copying
+TEST_F(HalfedgeGeometrySuite, CopyTest) {
+  auto asset = getAsset("bob_small.ply");
+  HalfedgeMesh& mesh = *asset.mesh;
+
+  VertexPositionGeometry& geometry = *asset.geometry;
+  
+  /* This SHOULD NOT compile, there is no implicit copy constructor
+  auto testF = [](VertexPositionGeometry g) {
+    g.requireVertexIndices();
+  };
+  testF(geometry);
+  */ 
+
+  // Copy vertex position
+  std::unique_ptr<VertexPositionGeometry> copy1 = geometry.copy();
+  copy1->requireFaceAreas();
+  
+  // Construct edge length geometry
+  copy1->requireEdgeLengths();
+  EdgeLengthGeometry eGeom(mesh, copy1->edgeLengths);
+
+  // Copy vertex position
+  std::unique_ptr<EdgeLengthGeometry> copy2 = eGeom.copy();
+  copy2->requireFaceAreas();
+}
+
+
 // ============================================================
 // =============== Quantity tests
 // ============================================================


### PR DESCRIPTION
Change the heat method for distance to use a lumped mass matrix; it works better.

Fix #15 by deleting not-actually-supported implicit copy of geometry objects. Also add copy tests, and implement missing copy for EdgeLengthGeometry.