### PR TITLE
Added STL parser

### DIFF
--- a/include/geometrycentral/surface/polygon_soup_mesh.h
+++ b/include/geometrycentral/surface/polygon_soup_mesh.h
@@ -3,18 +3,21 @@
 #include <cstdlib>
 #include <fstream>
 #include <memory>
+#include <regex>
 #include <stdexcept>
+#include <unordered_map>
 #include <vector>
 
-#include "geometrycentral/utilities/vector3.h"
 #include <geometrycentral/utilities/utilities.h>
+#include <geometrycentral/utilities/vector2.h>
+#include <geometrycentral/utilities/vector3.h>
 
 namespace geometrycentral {
 
 class PolygonSoupMesh {
 public:
   PolygonSoupMesh();
-  PolygonSoupMesh(std::string meshFilename);
+  PolygonSoupMesh(std::string meshFilename, std::string type = "");
   PolygonSoupMesh(const std::vector<std::vector<size_t>>& polygons_, const std::vector<Vector3>& vertexCoordinates_);
 
   // Mutate this mesh and by naively triangulating polygons
@@ -24,8 +27,16 @@ public:
   std::vector<std::vector<size_t>> polygons;
   std::vector<Vector3> vertexCoordinates;
 
+  // Mutate this mesh by merging vertices with identical floating point positions.
+  // Useful for loading .stl files, which don't contain information about which
+  // triangle corners meet at vertices.
+  void mergeIdenticalVertices();
+
 private:
-  void readMeshFromFile(std::string filename);
+  void readMeshFromObjFile(std::string filename);
+  void readMeshFromStlFile(std::string filename);
+  void readMeshFromAsciiStlFile(std::ifstream& in);
+  void readMeshFromBinaryStlFile(std::ifstream in);
 };
 
 } // namespace geometrycentral

--- a/include/geometrycentral/surface/polygon_soup_mesh.h
+++ b/include/geometrycentral/surface/polygon_soup_mesh.h
@@ -3,7 +3,6 @@
 #include <cstdlib>
 #include <fstream>
 #include <memory>
-#include <regex>
 #include <stdexcept>
 #include <unordered_map>
 #include <vector>

--- a/include/geometrycentral/utilities/vector2.h
+++ b/include/geometrycentral/utilities/vector2.h
@@ -78,6 +78,7 @@ template <typename T>
 Vector2 operator*(const T s, const Vector2& v);
 
 ::std::ostream& operator<<(std::ostream& output, const Vector2& v);
+::std::istream& operator<<(std::istream& input, Vector2& v);
 
 // Notice that all of these functions return a new vector when applicable.
 // The member functions above modify in place

--- a/include/geometrycentral/utilities/vector2.ipp
+++ b/include/geometrycentral/utilities/vector2.ipp
@@ -147,6 +147,13 @@ inline std::ostream& operator<<(std::ostream& output, const Vector2& v) {
   return output;
 }
 
+inline std::istream& operator>>(std::istream& input, Vector2& v) {
+  double x, y;
+  input >> x >> y;
+  v = Vector2{x, y};
+  return input;
+}
+
 } // namespace geometrycentral
 
 namespace std {
@@ -163,4 +170,3 @@ inline std::string to_string(geometrycentral::Vector2 vec) {
 
 
 } // namespace std
-

--- a/include/geometrycentral/utilities/vector3.h
+++ b/include/geometrycentral/utilities/vector3.h
@@ -62,6 +62,7 @@ Vector3 operator*(const T s, const Vector3& v);
 
 // Printing
 ::std::ostream& operator<<(::std::ostream& output, const Vector3& v);
+::std::istream& operator>>(::std::istream& intput, Vector3& v);
 
 double norm(const Vector3& v);
 double norm2(const Vector3& v);

--- a/include/geometrycentral/utilities/vector3.ipp
+++ b/include/geometrycentral/utilities/vector3.ipp
@@ -141,6 +141,13 @@ inline std::ostream& operator<<(std::ostream& output, const Vector3& v) {
   return output;
 }
 
+inline std::istream& operator>>(std::istream& input, Vector3& v) {
+  double x, y, z;
+  input >> x >> y >> z;
+  v = Vector3{x, y, z};
+  return input;
+}
+
 } // namespace geometrycentral
 
 namespace std {

--- a/src/surface/meshio.cpp
+++ b/src/surface/meshio.cpp
@@ -90,10 +90,19 @@ std::tuple<std::unique_ptr<HalfedgeMesh>, std::unique_ptr<VertexPositionGeometry
 
 std::tuple<std::unique_ptr<HalfedgeMesh>, std::unique_ptr<VertexPositionGeometry>> loadMesh_OBJ(std::string filename,
                                                                                                 bool verbose) {
-  PolygonSoupMesh soup(filename);
+  PolygonSoupMesh soup(filename, "obj");
   stripUnusedVertices(soup.vertexCoordinates, soup.polygons);
   return makeHalfedgeAndGeometry(soup.polygons, soup.vertexCoordinates, verbose);
 }
+
+std::tuple<std::unique_ptr<HalfedgeMesh>, std::unique_ptr<VertexPositionGeometry>> loadMesh_STL(std::string filename,
+                                                                                                bool verbose) {
+  PolygonSoupMesh soup(filename, std::string("stl"));
+  soup.mergeIdenticalVertices();
+  stripUnusedVertices(soup.vertexCoordinates, soup.polygons);
+  return makeHalfedgeAndGeometry(soup.polygons, soup.vertexCoordinates, verbose);
+}
+
 } // namespace
 
 std::tuple<std::unique_ptr<HalfedgeMesh>, std::unique_ptr<VertexPositionGeometry>>
@@ -125,6 +134,8 @@ loadMesh(std::string filename, bool verbose, std::string type) {
     return loadMesh_OBJ(filename, verbose);
   } else if (type == "ply") {
     return loadMesh_PLY(filename, verbose);
+  } else if (type == "stl") {
+    return loadMesh_STL(filename, verbose);
   } else {
     if (typeGiven) {
       throw std::runtime_error("Did not recognize mesh file type " + type);
@@ -133,7 +144,6 @@ loadMesh(std::string filename, bool verbose, std::string type) {
     }
   }
 }
-
 
 // connectivity loader helpers
 namespace {

--- a/src/surface/polygon_soup_mesh.cpp
+++ b/src/surface/polygon_soup_mesh.cpp
@@ -158,10 +158,12 @@ void PolygonSoupMesh::readMeshFromAsciiStlFile(std::ifstream& in) {
     std::string token;
     ss >> token;
     if (token != expected) {
-      std::cerr << "Error on line " << lineNum << ". Expected \"" << expected << "\" but token \"" << token << "\""
-                << std::endl;
-      std::cerr << "Full line: \"" << line << "\"" << std::endl;
-      exit(1);
+      std::ostringstream errorMessage;
+      errorMessage << "Failed to parse ASCII stl file." << std::endl
+                   << "Error on line " << lineNum << ". Expected \"" << expected << "\" but token \"" << token << "\""
+                   << std::endl
+                   << "Full line: \"" << line << "\"" << std::endl;
+      throw std::runtime_error(errorMessage.str());
     }
   };
 
@@ -309,7 +311,6 @@ void PolygonSoupMesh::mergeIdenticalVertices() {
   }
 
   vertexCoordinates = std::move(compressedPositions);
-  compressedPositions.clear();
 
   // Update face indices
   for (std::vector<size_t>& face : polygons) {

--- a/src/surface/polygon_soup_mesh.cpp
+++ b/src/surface/polygon_soup_mesh.cpp
@@ -10,7 +10,6 @@ namespace geometrycentral {
 
 PolygonSoupMesh::PolygonSoupMesh() {}
 
-// TODO, char* can get cast to bool, so using bool and string as optional arguments leads to horrible bugs
 PolygonSoupMesh::PolygonSoupMesh(std::string meshFilename, std::string type) {
 
   // Attempt to detect filename

--- a/src/surface/polygon_soup_mesh.cpp
+++ b/src/surface/polygon_soup_mesh.cpp
@@ -10,7 +10,36 @@ namespace geometrycentral {
 
 PolygonSoupMesh::PolygonSoupMesh() {}
 
-PolygonSoupMesh::PolygonSoupMesh(std::string meshFilename) { readMeshFromFile(meshFilename); }
+// TODO, char* can get cast to bool, so using bool and string as optional arguments leads to horrible bugs
+PolygonSoupMesh::PolygonSoupMesh(std::string meshFilename, std::string type) {
+
+  // Attempt to detect filename
+  bool typeGiven = type != "";
+  std::string::size_type sepInd = meshFilename.rfind('.');
+  if (!typeGiven) {
+    if (sepInd != std::string::npos) {
+      std::string extension;
+      extension = meshFilename.substr(sepInd + 1);
+
+      // Convert to all lowercase
+      std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
+      type = extension;
+    }
+  }
+
+  if (type == "obj") {
+    readMeshFromObjFile(meshFilename);
+  } else if (type == "stl") {
+    readMeshFromStlFile(meshFilename);
+  } else {
+    if (typeGiven) {
+      throw std::runtime_error("Did not recognize mesh file type " + type);
+    } else {
+      throw std::runtime_error("Could not detect file type to load mesh from " + meshFilename + ". (Found type " +
+                               type + ", but cannot load this)");
+    }
+  }
+}
 
 PolygonSoupMesh::PolygonSoupMesh(const std::vector<std::vector<size_t>>& polygons_,
                                  const std::vector<Vector3>& vertexCoordinates_)
@@ -72,8 +101,8 @@ Index parseFaceIndex(const std::string& token) {
 }
 
 // Read a .obj file containing a polygon mesh
-void PolygonSoupMesh::readMeshFromFile(std::string filename) {
-  //std::cout << "Reading mesh from file: " << filename << std::endl;
+void PolygonSoupMesh::readMeshFromObjFile(std::string filename) {
+  // std::cout << "Reading mesh from file: " << filename << std::endl;
 
   polygons.clear();
   vertexCoordinates.clear();
@@ -91,14 +120,13 @@ void PolygonSoupMesh::readMeshFromFile(std::string filename) {
     ss >> token;
 
     if (token == "v") {
-      double x, y, z;
-      ss >> x >> y >> z;
+      Vector3 position;
+      ss >> position;
 
-      vertexCoordinates.push_back(Vector3{x, y, z});
+      vertexCoordinates.push_back(position);
 
     } else if (token == "vt") {
       // Do nothing
-
     } else if (token == "vn") {
       // Do nothing
 
@@ -116,6 +144,177 @@ void PolygonSoupMesh::readMeshFromFile(std::string filename) {
       }
 
       polygons.push_back(face);
+    }
+  }
+}
+
+// Assumes that first line has already been consumed
+void PolygonSoupMesh::readMeshFromAsciiStlFile(std::ifstream& in) {
+  std::string line;
+  std::stringstream ss;
+  size_t lineNum = 1;
+
+  auto assertToken = [&](const std::string& expected) {
+    std::string token;
+    ss >> token;
+    if (token != expected) {
+      std::cerr << "Error on line " << lineNum << ". Expected \"" << expected << "\" but token \"" << token << "\""
+                << std::endl;
+      std::cerr << "Full line: \"" << line << "\"" << std::endl;
+      exit(1);
+    }
+  };
+
+  auto nextLine = [&]() {
+    if (!getline(in, line)) {
+      return false;
+    }
+
+    ss = std::stringstream(line);
+    lineNum++;
+    return true;
+  };
+
+  auto startsWithToken = [](const std::string& str, const std::string& prefix) {
+    std::stringstream ss(str);
+    std::string token;
+    ss >> token;
+    return token == prefix;
+  };
+
+  // Parse STL file
+  while (nextLine() && !startsWithToken(line, "endsolid")) {
+    assertToken("facet");
+    assertToken("normal");
+
+    // TODO: store this normal?
+    Vector3 normal;
+    ss >> normal;
+
+    nextLine();
+
+    assertToken("outer");
+    assertToken("loop");
+
+    std::vector<size_t> face;
+    while (nextLine() && !startsWithToken(line, "endloop")) {
+      assertToken("vertex");
+
+      Vector3 position;
+      ss >> position;
+      vertexCoordinates.push_back(position);
+
+      face.push_back(vertexCoordinates.size() - 1);
+    }
+
+    nextLine();
+    assertToken("endfacet");
+
+    // Orient face using normal
+    Vector3 faceNormal = cross(vertexCoordinates[face[1]] - vertexCoordinates[face[0]],
+                               vertexCoordinates[face[2]] - vertexCoordinates[face[0]]);
+    if (dot(faceNormal, normal) < 0) {
+      std::reverse(std::begin(face), std::end(face));
+    }
+
+    polygons.push_back(face);
+  }
+}
+
+void PolygonSoupMesh::readMeshFromBinaryStlFile(std::ifstream in) {
+  auto parseVector3 = [&](std::ifstream& in) {
+    char buffer[3 * sizeof(float)];
+    in.read(buffer, 3 * sizeof(float));
+    float* fVec = (float*)buffer;
+    return Vector3{fVec[0], fVec[1], fVec[2]};
+  };
+
+  char header[80];
+  char nTriangleChars[4];
+  in.read(header, 80);
+  in.read(nTriangleChars, 4);
+  unsigned int* intPtr = (unsigned int*)nTriangleChars;
+  size_t nTriangles = *intPtr;
+
+  for (size_t iT = 0; iT < nTriangles; ++iT) {
+    // TODO: store this normal?
+    Vector3 normal = parseVector3(in);
+    std::vector<size_t> face;
+    for (size_t iV = 0; iV < 3; ++iV) {
+      vertexCoordinates.push_back(parseVector3(in));
+      face.push_back(vertexCoordinates.size() - 1);
+    }
+
+    // Orient face using normal
+    Vector3 faceNormal = cross(vertexCoordinates[face[1]] - vertexCoordinates[face[0]],
+                               vertexCoordinates[face[2]] - vertexCoordinates[face[0]]);
+    if (dot(faceNormal, normal) < 0) {
+      std::reverse(std::begin(face), std::end(face));
+    }
+
+    polygons.push_back(face);
+    char dummy[2];
+    in.read(dummy, 2);
+  }
+}
+
+// Read a .stl file containing a polygon mesh
+void PolygonSoupMesh::readMeshFromStlFile(std::string filename) {
+  // TODO: read stl file name
+  polygons.clear();
+  vertexCoordinates.clear();
+
+  // Open the file
+  std::ifstream in(filename);
+  if (!in) throw std::invalid_argument("Could not open mesh file " + filename);
+
+  // parse stl format
+  std::string line;
+  getline(in, line);
+  std::stringstream ss(line);
+  std::string token;
+  ss >> token;
+  if (token == "solid") {
+    readMeshFromAsciiStlFile(in);
+  } else {
+    readMeshFromBinaryStlFile(std::ifstream(filename, std::ios::in | std::ios::binary));
+  }
+}
+
+// Mutate this mesh by merging vertices with identical floating point positions.
+// Useful for loading .stl files, which don't contain information about which
+// triangle corners meet at vertices.
+void PolygonSoupMesh::mergeIdenticalVertices() {
+  std::vector<Vector3> compressedPositions;
+  // Store mapping from original vertex index to merged vertex index
+  std::vector<size_t> compressVertex;
+  compressVertex.reserve(vertexCoordinates.size());
+
+  std::unordered_map<Vector3, size_t> canonicalIndex;
+
+  for (size_t iV = 0; iV < vertexCoordinates.size(); ++iV) {
+    Vector3 v = vertexCoordinates[iV];
+    auto it = canonicalIndex.find(v);
+
+    // Check if vertex exists in map or not
+    if (it == canonicalIndex.end()) {
+      compressedPositions.push_back(v);
+      size_t vecIndex = compressedPositions.size() - 1;
+      canonicalIndex[v] = vecIndex;
+      compressVertex.push_back(vecIndex);
+    } else {
+      size_t vecIndex = it->second;
+      compressVertex.push_back(vecIndex);
+    }
+  }
+
+  vertexCoordinates = std::move(compressedPositions);
+  compressedPositions.clear();
+
+  // Update face indices
+  for (std::vector<size_t>& face : polygons) {
+    for (size_t& iV : face) {
+      iV = compressVertex[iV];
     }
   }
 }


### PR DESCRIPTION
I added parsers for ASCII and binary STL files. I also added a function to merge vertices with the same positions, which lets you build halfedge meshes out of the STL models.

`mergeIdenticalVertices()` assumes that the vertices have exactly the same coordinates in floating point - I tried a version that merged vertices up to a small tolerance, but that was significantly slower, and this seems to work fine on the few Thingi10k models that I tried.