### PR TITLE
Unset EIGEN3_INCLUDE_DIR on failure

### DIFF
--- a/cmake/EigenChecker.cmake
+++ b/cmake/EigenChecker.cmake
@@ -47,6 +47,10 @@ function(eigen3checker GC_EIGEN_LOCATION EIGEN3_FIND_VERSION)
       set(EIGEN3_FOUND true PARENT_SCOPE)
       set(EIGEN3_INCLUDE_DIR ${EIGEN3_INCLUDE_DIR} PARENT_SCOPE)
     endif(${EIGEN3_VERSION} VERSION_LESS ${EIGEN3_FIND_VERSION})
+  else()
+    # Purge EIGEN3_INCLUDE_DIR value since it's invalid
+    # Required so find_path will actually search instead of defaulting
+    set(EIGEN3_INCLUDE_DIR "EIGEN3_INCLUDE_DIR-NOTFOUND" PARENT_SCOPE)
   endif()
 endfunction()
 

--- a/cmake/FindEigen3.cmake
+++ b/cmake/FindEigen3.cmake
@@ -36,27 +36,34 @@ if(NOT Eigen3_FIND_VERSION)
 endif(NOT Eigen3_FIND_VERSION)
 
 macro(_eigen3_check_version)
-  file(READ "${EIGEN3_INCLUDE_DIR}/Eigen/src/Core/util/Macros.h" _eigen3_version_header)
+  if(EXISTS "${EIGEN3_INCLUDE_DIR}/Eigen/src/Core/util/Macros.h")
+    file(READ "${EIGEN3_INCLUDE_DIR}/Eigen/src/Core/util/Macros.h" _eigen3_version_header)
 
-  string(REGEX MATCH "define[ \t]+EIGEN_WORLD_VERSION[ \t]+([0-9]+)" _eigen3_world_version_match "${_eigen3_version_header}")
-  set(EIGEN3_WORLD_VERSION "${CMAKE_MATCH_1}")
-  string(REGEX MATCH "define[ \t]+EIGEN_MAJOR_VERSION[ \t]+([0-9]+)" _eigen3_major_version_match "${_eigen3_version_header}")
-  set(EIGEN3_MAJOR_VERSION "${CMAKE_MATCH_1}")
-  string(REGEX MATCH "define[ \t]+EIGEN_MINOR_VERSION[ \t]+([0-9]+)" _eigen3_minor_version_match "${_eigen3_version_header}")
-  set(EIGEN3_MINOR_VERSION "${CMAKE_MATCH_1}")
+    string(REGEX MATCH "define[ \t]+EIGEN_WORLD_VERSION[ \t]+([0-9]+)" _eigen3_world_version_match "${_eigen3_version_header}")
+    set(EIGEN3_WORLD_VERSION "${CMAKE_MATCH_1}")
+    string(REGEX MATCH "define[ \t]+EIGEN_MAJOR_VERSION[ \t]+([0-9]+)" _eigen3_major_version_match "${_eigen3_version_header}")
+    set(EIGEN3_MAJOR_VERSION "${CMAKE_MATCH_1}")
+    string(REGEX MATCH "define[ \t]+EIGEN_MINOR_VERSION[ \t]+([0-9]+)" _eigen3_minor_version_match "${_eigen3_version_header}")
+    set(EIGEN3_MINOR_VERSION "${CMAKE_MATCH_1}")
 
-  set(EIGEN3_VERSION ${EIGEN3_WORLD_VERSION}.${EIGEN3_MAJOR_VERSION}.${EIGEN3_MINOR_VERSION})
-  if(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
+    set(EIGEN3_VERSION ${EIGEN3_WORLD_VERSION}.${EIGEN3_MAJOR_VERSION}.${EIGEN3_MINOR_VERSION})
+    if(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
+      set(EIGEN3_VERSION_OK FALSE)
+    else(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
+      set(EIGEN3_VERSION_OK TRUE)
+    endif(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
+
+    if(NOT EIGEN3_VERSION_OK)
+
+      message(STATUS "Eigen3 version ${EIGEN3_VERSION} found in ${EIGEN3_INCLUDE_DIR}, "
+                     "but at least version ${Eigen3_FIND_VERSION} is required")
+    endif(NOT EIGEN3_VERSION_OK)
+  else()
+    # Purge EIGEN3_INCLUDE_DIR value since it's invalid
+    # Required so find_path will actually search instead of defaulting
+    set(EIGEN3_INCLUDE_DIR "EIGEN3_INCLUDE_DIR-NOTFOUND")
     set(EIGEN3_VERSION_OK FALSE)
-  else(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
-    set(EIGEN3_VERSION_OK TRUE)
-  endif(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
-
-  if(NOT EIGEN3_VERSION_OK)
-
-    message(STATUS "Eigen3 version ${EIGEN3_VERSION} found in ${EIGEN3_INCLUDE_DIR}, "
-                   "but at least version ${Eigen3_FIND_VERSION} is required")
-  endif(NOT EIGEN3_VERSION_OK)
+  endif()
 endmacro(_eigen3_check_version)
 
 if (EIGEN3_INCLUDE_DIR)


### PR DESCRIPTION
Under certain awful system configuration conditions... it's apparently possible for `find_path()` to set a bogus Eigen location in `EIGEN3_INCLUDE_DIR`. Subsequent calls to `find_path()` will default to the previously found location even though its wrong (c.f. https://cmake.org/cmake/help/latest/command/find_path.html second to last paragraph).

Also `find_path(<var> ...)` expects a value of the form `<var>-NOTFOUND` or if the variable is uninitialized. The empty string value, for example, appears to also satisfy the cached value check.

This PR explicitly sets `EIGEN3_INCLUDE_DIR` to value `EIGEN3_INCLUDE_DIR-NOTFOUND` to avoid using an incorrect cached path in the future.