### PR TITLE
bugfix GCC8.2 -Werror=catch-value=

### DIFF
--- a/src/surface/rich_surface_mesh_data.cpp
+++ b/src/surface/rich_surface_mesh_data.cpp
@@ -261,7 +261,7 @@ VertexData<Vector3> RichSurfaceMeshData::getVertexColors() {
     }
     return color;
 
-  } catch (std::runtime_error orig_e) {
+  } catch (std::runtime_error &orig_e) {
 
     // If that doesn't work, try float
     try {
@@ -274,7 +274,7 @@ VertexData<Vector3> RichSurfaceMeshData::getVertexColors() {
         color[v][2] = b[v];
       }
       return color;
-    } catch (std::runtime_error second_e) {
+    } catch (std::runtime_error &second_e) {
       throw std::runtime_error("Could not find vertex colors in PLY file, as uchar or float");
     }
   }


### PR DESCRIPTION
I had a compile error with GCC8.2 with -Werror and the exceptions ([https://www.nsnam.org/bugzilla/show_bug.cgi?id=2917](https://www.nsnam.org/bugzilla/show_bug.cgi?id=2917))