### PR TITLE
signpost_intrinsic_triangulation: implement equivalentPointOn{Intrinsic,Input}

### DIFF
--- a/include/geometrycentral/surface/signpost_intrinsic_triangulation.h
+++ b/include/geometrycentral/surface/signpost_intrinsic_triangulation.h
@@ -64,10 +64,10 @@ public:
   // ======================================================
 
   // Given a point on the input triangulation, returns the corresponding point on the intrinsic triangulation
-  SurfacePoint equivalentPointOnIntrinsic(const SurfacePoint& pointOnInput);
+  SurfacePoint equivalentPointOnIntrinsic(SurfacePoint pointOnInput);
 
   // Given a point on the intrinsic triangulation, returns the corresponding point on the input triangulation
-  SurfacePoint equivalentPointOnInput(const SurfacePoint& pointOnIntrinsic);
+  SurfacePoint equivalentPointOnInput(SurfacePoint pointOnIntrinsic);
 
   // Trace out the edges of the intrinsic triangulation along the surface of the input mesh.
   // Each path is ordered along edge.halfedge(), and includes both the start and end points

--- a/include/geometrycentral/surface/surface_point.h
+++ b/include/geometrycentral/surface/surface_point.h
@@ -55,6 +55,9 @@ struct SurfacePoint {
   // Return the nearest vertex to this surface point
   inline Vertex nearestVertex() const;
 
+  // Return the equivalent surface point in the 'reduced' form (can be seen as the inverse of inSomeFace).
+  // An edge point may be reduced to a vertex point, and a face point may be reduced to an edge point or a vertex point.
+  inline SurfacePoint reduced() const;
 
   // Linearly interpolate data at vertices to this point.
   // T must support addition and multiplication by a double.

--- a/include/geometrycentral/surface/surface_point.ipp
+++ b/include/geometrycentral/surface/surface_point.ipp
@@ -176,6 +176,42 @@ inline Vertex SurfacePoint::nearestVertex() const {
   return vertex;
 }
 
+inline SurfacePoint SurfacePoint::reduced() const {
+  switch (type) {
+  case SurfacePointType::Vertex: {
+    return *this;
+  }
+  case SurfacePointType::Edge: {
+    if (tEdge == 0. || tEdge == 1.)
+      return SurfacePoint(nearestVertex());
+    else
+      return *this;
+  }
+  case SurfacePointType::Face: {
+    if (faceCoords.x == 1. || faceCoords.y == 1. || faceCoords.z == 1.)
+      return SurfacePoint(nearestVertex());
+    else if (faceCoords.z == 0.) {
+        Edge e = face.halfedge().edge();
+        double tEdge = face == e.halfedge().face() ? faceCoords.y : faceCoords.x;
+        return SurfacePoint(e, tEdge);
+    } else if (faceCoords.x == 0.) {
+        Edge e = face.halfedge().next().edge();
+        double tEdge = face == e.halfedge().face() ? faceCoords.z : faceCoords.y;
+        return SurfacePoint(e, tEdge);
+    } else if (faceCoords.y == 0.) {
+        Edge e = face.halfedge().next().next().edge();
+        double tEdge = face == e.halfedge().face() ? faceCoords.x : faceCoords.z;
+        return SurfacePoint(e, tEdge);
+    } else {
+      return *this;
+    }
+  }
+  }
+
+  throw std::logic_error("bad switch");
+  return {};
+}
+
 template <typename T>
 inline T SurfacePoint::interpolate(const VertexData<T>& data) const {
 

--- a/src/surface/trace_geodesic.cpp
+++ b/src/surface/trace_geodesic.cpp
@@ -699,6 +699,7 @@ TraceGeodesicResult traceGeodesic(IntrinsicGeometryInterface& geom, SurfacePoint
     geom.unrequireHalfedgeVectorsInVertex();
     geom.unrequireHalfedgeVectorsInFace();
 
+    result.endPoint = startP;
     result.endingDir = Vector2::zero();
 
     // probably want to ensure we still return a point in a face...

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -98,6 +98,7 @@ set(TEST_SRCS
   src/halfedge_geometry_test.cpp
   src/surface_misc_test.cpp
   src/linear_algebra_test.cpp
+  src/signpost_intrinsic_triangulation_test.cpp
 )
 
 add_executable(geometry-central-test "${TEST_SRCS}")

--- a/test/src/signpost_intrinsic_triangulation_test.cpp
+++ b/test/src/signpost_intrinsic_triangulation_test.cpp
@@ -1,0 +1,194 @@
+#include "geometrycentral/surface/signpost_intrinsic_triangulation.h"
+
+#include "load_test_meshes.h"
+
+using namespace geometrycentral;
+using namespace geometrycentral::surface;
+
+// helpers
+namespace {
+
+std::mt19937 mt(42);
+
+double unitRand() {
+  std::uniform_real_distribution<double> dist(0.0, 1.0);
+  return dist(mt);
+}
+
+void insertVerticesAtRandom(SignpostIntrinsicTriangulation& signpostTri) {
+  for (Face f : signpostTri.intrinsicMesh->faces()) {
+    if (unitRand() > 0.5) {
+      signpostTri.insertVertex(SurfacePoint{f, {1/3., 1/3., 1/3.}});
+    }
+  }
+}
+
+void flipEdgesAtRandom(SignpostIntrinsicTriangulation& signpostTri) {
+  for (Edge e : signpostTri.intrinsicMesh->edges()) {
+    if (unitRand() > 0.5) {
+      signpostTri.flipEdgeIfPossible(e);
+    }
+  }
+}
+
+void mutateIntrinsicMesh(SignpostIntrinsicTriangulation& signpostTri) {
+  insertVerticesAtRandom(signpostTri);
+  flipEdgesAtRandom(signpostTri);
+}
+
+double getBoundingBoxDiagonal(VertexPositionGeometry& geometry) {
+  Vector3 minP = Vector3::constant(std::numeric_limits<double>::infinity());
+  Vector3 maxP = Vector3::constant(-std::numeric_limits<double>::infinity());
+  for (Vertex v : geometry.mesh.vertices()) {
+    Vector3 p = geometry.vertexPositions[v];
+    minP = componentwiseMin(minP, p);
+    maxP = componentwiseMax(maxP, p);
+  }
+  return norm(minP - maxP);
+}
+
+const int N = 7;
+const double EPS = 1e-3;
+
+} // namespace
+
+class SignpostIntrinsicTriangulationSuite : public MeshAssetSuite {};
+
+// ============================================================
+// =============== Equivalent point tests
+// ============================================================
+
+TEST_F(SignpostIntrinsicTriangulationSuite, EquivalentPointOnIntrinsic_FacePoint) {
+  for (auto& asset : {getAsset("bob_small.ply", true), getAsset("lego.ply", true), getAsset("sphere_small.ply", true), getAsset("spot.ply", true)}) {
+    asset.printThyName();
+    SignpostIntrinsicTriangulation signpostTri(*asset.manifoldMesh, *asset.geometry);
+
+    mutateIntrinsicMesh(signpostTri);
+
+    double boundingBoxDiagonal = getBoundingBoxDiagonal(*asset.geometry);
+
+    for (Face f : signpostTri.inputMesh.faces()) {
+      Vector3 i;
+      for (i[0] = 1; i[0] < N; ++i[0]) {
+        for (i[1] = 1; i[1] < N - i[0]; ++i[1]) {
+          i[2] = N - i[0] - i[1];
+          Vector3 faceCoords = i / N;
+          SurfacePoint pointOnInput_before{f, faceCoords};
+          SurfacePoint pointOnIntrinsic = signpostTri.equivalentPointOnIntrinsic(pointOnInput_before);
+          SurfacePoint pointOnInput_after = signpostTri.equivalentPointOnInput(pointOnIntrinsic);
+          double error = (pointOnInput_before.interpolate(asset.geometry->inputVertexPositions) - pointOnInput_after.interpolate(asset.geometry->inputVertexPositions)).norm();
+          EXPECT_LT(error, boundingBoxDiagonal * EPS);
+        }
+      }
+    }
+  }
+}
+
+TEST_F(SignpostIntrinsicTriangulationSuite, EquivalentPointOnInput_FacePoint) {
+  for (auto& asset : {getAsset("bob_small.ply", true), getAsset("lego.ply", true), getAsset("sphere_small.ply", true), getAsset("spot.ply", true)}) {
+    asset.printThyName();
+    SignpostIntrinsicTriangulation signpostTri(*asset.manifoldMesh, *asset.geometry);
+
+    mutateIntrinsicMesh(signpostTri);
+
+    double boundingBoxDiagonal = getBoundingBoxDiagonal(*asset.geometry);
+
+    for (Face f : signpostTri.intrinsicMesh->faces()) {
+      Vector3 i;
+      for (i[0] = 1; i[0] < N; ++i[0]) {
+        for (i[1] = 1; i[1] < N - i[0]; ++i[1]) {
+          i[2] = N - i[0] - i[1];
+          Vector3 faceCoords = i / N;
+          SurfacePoint pointOnIntrinsic_before{f, faceCoords};
+          SurfacePoint pointOnInput_before = signpostTri.equivalentPointOnInput(pointOnIntrinsic_before);
+          SurfacePoint pointOnIntrinsic_after = signpostTri.equivalentPointOnIntrinsic(pointOnInput_before);
+          SurfacePoint pointOnInput_after = signpostTri.equivalentPointOnInput(pointOnIntrinsic_after);
+          double error = (pointOnInput_before.interpolate(asset.geometry->inputVertexPositions) - pointOnInput_after.interpolate(asset.geometry->inputVertexPositions)).norm();
+          EXPECT_LT(error, boundingBoxDiagonal * EPS);
+        }
+      }
+    }
+  }
+}
+
+TEST_F(SignpostIntrinsicTriangulationSuite, EquivalentPointOnIntrinsic_EdgePoint) {
+  for (auto& asset : {getAsset("bob_small.ply", true), getAsset("lego.ply", true), getAsset("sphere_small.ply", true), getAsset("spot.ply", true)}) {
+    asset.printThyName();
+    SignpostIntrinsicTriangulation signpostTri(*asset.manifoldMesh, *asset.geometry);
+
+    mutateIntrinsicMesh(signpostTri);
+
+    double boundingBoxDiagonal = getBoundingBoxDiagonal(*asset.geometry);
+
+    for (Edge e : signpostTri.inputMesh.edges()) {
+      for (double i = 1; i < N; ++i) {
+        SurfacePoint pointOnInput_before{e, i / N};
+        SurfacePoint pointOnIntrinsic = signpostTri.equivalentPointOnIntrinsic(pointOnInput_before);
+        SurfacePoint pointOnInput_after = signpostTri.equivalentPointOnInput(pointOnIntrinsic);
+        double error = (pointOnInput_before.interpolate(asset.geometry->inputVertexPositions) - pointOnInput_after.interpolate(asset.geometry->inputVertexPositions)).norm();
+        EXPECT_LT(error, boundingBoxDiagonal * EPS);
+      }
+    }
+  }
+}
+
+TEST_F(SignpostIntrinsicTriangulationSuite, EquivalentPointOnInput_EdgePoint) {
+  for (auto& asset : {getAsset("bob_small.ply", true), getAsset("lego.ply", true), getAsset("sphere_small.ply", true), getAsset("spot.ply", true)}) {
+    asset.printThyName();
+    SignpostIntrinsicTriangulation signpostTri(*asset.manifoldMesh, *asset.geometry);
+
+    mutateIntrinsicMesh(signpostTri);
+
+    double boundingBoxDiagonal = getBoundingBoxDiagonal(*asset.geometry);
+
+    for (Edge e : signpostTri.intrinsicMesh->edges()) {
+      for (double i = 1; i < N; ++i) {
+        SurfacePoint pointOnIntrinsic_before{e, i / N};
+        SurfacePoint pointOnInput_before = signpostTri.equivalentPointOnInput(pointOnIntrinsic_before);
+        SurfacePoint pointOnIntrinsic_after = signpostTri.equivalentPointOnIntrinsic(pointOnInput_before);
+        SurfacePoint pointOnInput_after = signpostTri.equivalentPointOnInput(pointOnIntrinsic_after);
+        double error = (pointOnInput_before.interpolate(asset.geometry->inputVertexPositions) - pointOnInput_after.interpolate(asset.geometry->inputVertexPositions)).norm();
+        EXPECT_LT(error, boundingBoxDiagonal * EPS);
+      }
+    }
+  }
+}
+
+TEST_F(SignpostIntrinsicTriangulationSuite, EquivalentPointOnIntrinsic_VertexPoint) {
+  for (auto& asset : {getAsset("bob_small.ply", true), getAsset("lego.ply", true), getAsset("sphere_small.ply", true), getAsset("spot.ply", true)}) {
+    asset.printThyName();
+    SignpostIntrinsicTriangulation signpostTri(*asset.manifoldMesh, *asset.geometry);
+
+    mutateIntrinsicMesh(signpostTri);
+
+    double boundingBoxDiagonal = getBoundingBoxDiagonal(*asset.geometry);
+
+    for (Vertex v : signpostTri.inputMesh.vertices()) {
+      SurfacePoint pointOnInput_before{v};
+      SurfacePoint pointOnIntrinsic = signpostTri.equivalentPointOnIntrinsic(pointOnInput_before);
+      SurfacePoint pointOnInput_after = signpostTri.equivalentPointOnInput(pointOnIntrinsic);
+      double error = (pointOnInput_before.interpolate(asset.geometry->inputVertexPositions) - pointOnInput_after.interpolate(asset.geometry->inputVertexPositions)).norm();
+      EXPECT_LT(error, boundingBoxDiagonal * EPS);
+    }
+  }
+}
+
+TEST_F(SignpostIntrinsicTriangulationSuite, EquivalentPointOnInput_VertexPoint) {
+  for (auto& asset : {getAsset("bob_small.ply", true), getAsset("lego.ply", true), getAsset("sphere_small.ply", true), getAsset("spot.ply", true)}) {
+    asset.printThyName();
+    SignpostIntrinsicTriangulation signpostTri(*asset.manifoldMesh, *asset.geometry);
+
+    mutateIntrinsicMesh(signpostTri);
+
+    double boundingBoxDiagonal = getBoundingBoxDiagonal(*asset.geometry);
+
+    for (Vertex v : signpostTri.intrinsicMesh->vertices()) {
+      SurfacePoint pointOnIntrinsic_before{v};
+      SurfacePoint pointOnInput_before = signpostTri.equivalentPointOnInput(pointOnIntrinsic_before);
+      SurfacePoint pointOnIntrinsic_after = signpostTri.equivalentPointOnIntrinsic(pointOnInput_before);
+      SurfacePoint pointOnInput_after = signpostTri.equivalentPointOnInput(pointOnIntrinsic_after);
+      double error = (pointOnInput_before.interpolate(asset.geometry->inputVertexPositions) - pointOnInput_after.interpolate(asset.geometry->inputVertexPositions)).norm();
+      EXPECT_LT(error, boundingBoxDiagonal * EPS);
+    }
+  }
+}


### PR DESCRIPTION
I played with the signpost intrinsic triangulation demo and realized that `equivalentPointOn{Intrinsic,Input}` are left unimplemented, so here they are. I needed them for testing my own little research idea that turned out to be doomed, but hopefully someone will find this code useful in the future.

This implementation has a robustness/accuracy issue despite my attempt, as evidenced in the test. In some rare but non-negligible cases, the positional error after going to/from inputMesh and intrinsicMesh gets quite large (more than 50% of the bounding box diagonal). Hopefully someone can fix this bug in the future :)

P.S.
Thank you so much for maintaining this awesome library!
