### PR TITLE
Fix triangulate to return list of new faces

### DIFF
--- a/src/surface/manifold_surface_mesh.cpp
+++ b/src/surface/manifold_surface_mesh.cpp
@@ -1613,7 +1613,7 @@ std::vector<Face> ManifoldSurfaceMesh::triangulate(Face f) {
   Halfedge connectHe = f.halfedge();
   for (size_t i = 2; i + 1 < neighHalfedges.size(); i++) {
     connectHe = connectVertices(connectHe, neighHalfedges[i]);
-    allFaces.emplace_back(neighHalfedges[i].face());
+    allFaces.emplace_back(connectHe.twin().face());
   }
 
   modificationTick++;


### PR DESCRIPTION
Currently it returns the old face n times.

The halfedge returned by `connectVertices` is the halfedge in the old face that is adjacent to the new face. So `connectHe.twin().face()` is guaranteed to be in the newly-created face.