### PR TITLE
Add method for loading UVs with ManifoldSurfaceMesh

### DIFF
--- a/docs/docs/surface/utilities/io.md
+++ b/docs/docs/surface/utilities/io.md
@@ -101,9 +101,17 @@ std::tie(mesh2, geometry2) = readSurfaceMesh("spot_messy.obj");
     When reading from a stream, the type _must_ be specified and cannot be automatically inferred.
 
 
-??? func "`#!cpp std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>, std::unique_ptr<CornerData<Vector2>>> readParameterizedManifoldSurfaceMesh(std::istream& in, std::string type)`"
+??? func "`#!cpp std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>, std::unique_ptr<CornerData<Vector2>>> readParameterizedManifoldSurfaceMesh(std::string filename, std::string type="")`"
 
-    Loads a manifold surface mesh plus UV (texture) coordinates from a file.  Currently only OBJ files are supported.
+    Loads a manifold surface mesh plus UV (texture) coordinates from a file.  See other variants for details.
+
+    Currently only OBJ files are supported.
+
+??? func "`#!cpp std::tuple<std::unique_ptr<SurfaceMesh>, std::unique_ptr<VertexPositionGeometry>, std::unique_ptr<CornerData<Vector2>>> readParameterizedSurfaceMesh(std::string filename, std::string type="")`"
+
+    Loads a general surface mesh plus UV (texture) coordinates from a file.  See other variants for details.
+
+    Currently only OBJ files are supported.
 
 ## Writing meshes
 

--- a/docs/docs/surface/utilities/io.md
+++ b/docs/docs/surface/utilities/io.md
@@ -101,6 +101,9 @@ std::tie(mesh2, geometry2) = readSurfaceMesh("spot_messy.obj");
     When reading from a stream, the type _must_ be specified and cannot be automatically inferred.
 
 
+??? func "`#!cpp std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>, std::unique_ptr<CornerData<Vector2>>> readParameterizedManifoldSurfaceMesh(std::istream& in, std::string type)`"
+
+    Loads a manifold surface mesh plus UV (texture) coordinates from a file.  Currently only OBJ files are supported.
 
 ## Writing meshes
 

--- a/include/geometrycentral/surface/meshio.h
+++ b/include/geometrycentral/surface/meshio.h
@@ -23,6 +23,8 @@ std::tuple<std::unique_ptr<SurfaceMesh>, std::unique_ptr<VertexPositionGeometry>
 // Load a manifold surface mesh; an exception will by thrown if the mesh is not manifold.
 std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>
 readManifoldSurfaceMesh(std::string filename, std::string type = "");
+std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>
+readManifoldSurfaceMesh(std::istream& in, std::string type);
 
 // Load a mesh with UV coordinates, which will be stored as data at triangle
 // corners (to allow for UVs that are discontinuous across edges, e.g., at cuts)

--- a/include/geometrycentral/surface/meshio.h
+++ b/include/geometrycentral/surface/meshio.h
@@ -28,11 +28,12 @@ readManifoldSurfaceMesh(std::istream& in, std::string type);
 
 // Load a mesh with UV coordinates, which will be stored as data at triangle
 // corners (to allow for UVs that are discontinuous across edges, e.g., at cuts)
-std::tuple<
-   std::unique_ptr<ManifoldSurfaceMesh>,
-   std::unique_ptr<VertexPositionGeometry>,
-   std::unique_ptr<CornerData<Vector2>>>
+std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>,
+           std::unique_ptr<CornerData<Vector2>>>
 readParameterizedManifoldSurfaceMesh(std::string filename, std::string type = "");
+std::tuple<std::unique_ptr<SurfaceMesh>, std::unique_ptr<VertexPositionGeometry>,
+           std::unique_ptr<CornerData<Vector2>>>
+readParameterizedSurfaceMesh(std::string filename, std::string type = "");
 
 // Legacy method, prefer one of the variants above
 std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>

--- a/include/geometrycentral/surface/meshio.h
+++ b/include/geometrycentral/surface/meshio.h
@@ -23,8 +23,6 @@ std::tuple<std::unique_ptr<SurfaceMesh>, std::unique_ptr<VertexPositionGeometry>
 // Load a manifold surface mesh; an exception will by thrown if the mesh is not manifold.
 std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>
 readManifoldSurfaceMesh(std::string filename, std::string type = "");
-std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>
-readManifoldSurfaceMesh(std::istream& in, std::string type, std::unique_ptr<CornerData<Vector2>> texcoords = std::unique_ptr<CornerData<Vector2>>(nullptr));
 
 // Load a mesh with UV coordinates, which will be stored as data at triangle
 // corners (to allow for UVs that are discontinuous across edges, e.g., at cuts)

--- a/include/geometrycentral/surface/meshio.h
+++ b/include/geometrycentral/surface/meshio.h
@@ -24,8 +24,15 @@ std::tuple<std::unique_ptr<SurfaceMesh>, std::unique_ptr<VertexPositionGeometry>
 std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>
 readManifoldSurfaceMesh(std::string filename, std::string type = "");
 std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>
-readManifoldSurfaceMesh(std::istream& in, std::string type);
+readManifoldSurfaceMesh(std::istream& in, std::string type, std::unique_ptr<CornerData<Vector2>> texcoords = std::unique_ptr<CornerData<Vector2>>(nullptr));
 
+// Load a mesh with UV coordinates, which will be stored as data at triangle
+// corners (to allow for UVs that are discontinuous across edges, e.g., at cuts)
+std::tuple<
+   std::unique_ptr<ManifoldSurfaceMesh>,
+   std::unique_ptr<VertexPositionGeometry>,
+   std::unique_ptr<CornerData<Vector2>>>
+readParameterizedManifoldSurfaceMesh(std::string filename, std::string type = "");
 
 // Legacy method, prefer one of the variants above
 std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>

--- a/include/geometrycentral/surface/surface_mesh_factories.h
+++ b/include/geometrycentral/surface/surface_mesh_factories.h
@@ -18,36 +18,39 @@ makeManifoldSurfaceMeshAndGeometry(const std::vector<std::vector<size_t>>& polyg
                                    const std::vector<Vector3> vertexPositions);
 
 
-// Like above, but with known twin connectivity
-std::tuple<std::unique_ptr<ManifoldSurfaceMesh>,
-           std::unique_ptr<VertexPositionGeometry>,
+// Like above, but with known twin connectivity (full, general version)
+std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>,
            std::unique_ptr<CornerData<Vector2>>>
 makeManifoldSurfaceMeshAndGeometry(const std::vector<std::vector<size_t>>& polygons,
                                    const std::vector<std::vector<std::tuple<size_t, size_t>>>& twins,
                                    const std::vector<Vector3> vertexPositions,
-                                   const std::vector<std::vector<Vector2>>& paramCoordinates );
+                                   const std::vector<std::vector<Vector2>>& paramCoordinates);
 
 // Make a manifold surface mesh with both geometry and UV coordinates
-std::tuple<
-   std::unique_ptr<ManifoldSurfaceMesh>,
-   std::unique_ptr<VertexPositionGeometry>,
-   std::unique_ptr<CornerData<Vector2>>>
-makeParameterizedManifoldSurfaceMeshAndGeometry(
-      const std::vector<std::vector<size_t>>& polygons,
-      const std::vector<Vector3> vertexPositions,
-      const std::vector<std::vector<Vector2>>& paramCoordinates );
+std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>,
+           std::unique_ptr<CornerData<Vector2>>>
+makeParameterizedManifoldSurfaceMeshAndGeometry(const std::vector<std::vector<size_t>>& polygons,
+                                                const std::vector<Vector3> vertexPositions,
+                                                const std::vector<std::vector<Vector2>>& paramCoordinates);
 
 // Same a above, but constructs a potentially-nonmanifold surface mesh
 std::tuple<std::unique_ptr<SurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>
 makeSurfaceMeshAndGeometry(const std::vector<std::vector<size_t>>& polygons,
-                               const std::vector<Vector3> vertexPositions);
+                           const std::vector<Vector3> vertexPositions);
 
 
-// Like above, but with known twin connectivity
-std::tuple<std::unique_ptr<SurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>
+// Like above, but with known twin connectivity (full, general version)
+std::tuple<std::unique_ptr<SurfaceMesh>, std::unique_ptr<VertexPositionGeometry>, std::unique_ptr<CornerData<Vector2>>>
 makeSurfaceMeshAndGeometry(const std::vector<std::vector<size_t>>& polygons,
-                               const std::vector<std::vector<std::tuple<size_t, size_t>>>& twins,
-                               const std::vector<Vector3> vertexPositions);
+                           const std::vector<std::vector<std::tuple<size_t, size_t>>>& twins,
+                           const std::vector<Vector3> vertexPositions,
+                           const std::vector<std::vector<Vector2>>& paramCoordinates);
+
+// Like above, but with UV coordinates
+std::tuple<std::unique_ptr<SurfaceMesh>, std::unique_ptr<VertexPositionGeometry>, std::unique_ptr<CornerData<Vector2>>>
+makeParameterizedSurfaceMeshAndGeometry(const std::vector<std::vector<size_t>>& polygons,
+                                        const std::vector<Vector3> vertexPositions,
+                                        const std::vector<std::vector<Vector2>>& paramCoordinates);
 
 
 // Make a manifold mesh from Eigen matrices
@@ -60,6 +63,7 @@ template <typename Scalar_V, typename Scalar_F>
 std::tuple<std::unique_ptr<SurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>
 makeSurfaceMeshAndGeometry(const Eigen::MatrixBase<Scalar_V>& vMat, const Eigen::MatrixBase<Scalar_F>& fMat);
 
-}}
+} // namespace surface
+} // namespace geometrycentral
 
 #include "geometrycentral/surface/surface_mesh_factories.ipp"

--- a/include/geometrycentral/surface/surface_mesh_factories.h
+++ b/include/geometrycentral/surface/surface_mesh_factories.h
@@ -14,15 +14,28 @@ namespace surface {
 
 // Assumes manifoldness, errors our if not
 std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>
-makeManifoldSurfaceMeshAndGeometry(const std::vector<std::vector<size_t>>& polygons, const std::vector<Vector3> vertexPositions);
+makeManifoldSurfaceMeshAndGeometry(const std::vector<std::vector<size_t>>& polygons,
+                                   const std::vector<Vector3> vertexPositions);
 
 
 // Like above, but with known twin connectivity
-std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>
+std::tuple<std::unique_ptr<ManifoldSurfaceMesh>,
+           std::unique_ptr<VertexPositionGeometry>,
+           std::unique_ptr<CornerData<Vector2>>>
 makeManifoldSurfaceMeshAndGeometry(const std::vector<std::vector<size_t>>& polygons,
-                        const std::vector<std::vector<std::tuple<size_t, size_t>>>& twins,
-                        const std::vector<Vector3> vertexPositions);
+                                   const std::vector<std::vector<std::tuple<size_t, size_t>>>& twins,
+                                   const std::vector<Vector3> vertexPositions,
+                                   const std::vector<std::vector<Vector2>>& paramCoordinates );
 
+// Make a manifold surface mesh with both geometry and UV coordinates
+std::tuple<
+   std::unique_ptr<ManifoldSurfaceMesh>,
+   std::unique_ptr<VertexPositionGeometry>,
+   std::unique_ptr<CornerData<Vector2>>>
+makeParameterizedManifoldSurfaceMeshAndGeometry(
+      const std::vector<std::vector<size_t>>& polygons,
+      const std::vector<Vector3> vertexPositions,
+      const std::vector<std::vector<Vector2>>& paramCoordinates );
 
 // Same a above, but constructs a potentially-nonmanifold surface mesh
 std::tuple<std::unique_ptr<SurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>

--- a/src/surface/halfedge_factories.cpp
+++ b/src/surface/halfedge_factories.cpp
@@ -17,7 +17,12 @@ std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionG
 makeHalfedgeAndGeometry(const std::vector<std::vector<size_t>>& polygons,
                         const std::vector<std::vector<std::tuple<size_t, size_t>>>& twins,
                         const std::vector<Vector3> vertexPositions) {
-  return makeManifoldSurfaceMeshAndGeometry(polygons, twins, vertexPositions);
+  auto lvals = makeManifoldSurfaceMeshAndGeometry(polygons, twins, vertexPositions,{});
+
+  return std::tuple<std::unique_ptr<ManifoldSurfaceMesh>,
+         std::unique_ptr<VertexPositionGeometry>>
+  ( std::move(std::get<0>(lvals)), //mesh
+    std::move(std::get<1>(lvals)) ); // geometry
 }
 
 

--- a/src/surface/halfedge_factories.cpp
+++ b/src/surface/halfedge_factories.cpp
@@ -17,12 +17,11 @@ std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionG
 makeHalfedgeAndGeometry(const std::vector<std::vector<size_t>>& polygons,
                         const std::vector<std::vector<std::tuple<size_t, size_t>>>& twins,
                         const std::vector<Vector3> vertexPositions) {
-  auto lvals = makeManifoldSurfaceMeshAndGeometry(polygons, twins, vertexPositions,{});
+  auto lvals = makeManifoldSurfaceMeshAndGeometry(polygons, twins, vertexPositions, {});
 
   return std::tuple<std::unique_ptr<ManifoldSurfaceMesh>,
-         std::unique_ptr<VertexPositionGeometry>>
-  ( std::move(std::get<0>(lvals)), //mesh
-    std::move(std::get<1>(lvals)) ); // geometry
+                    std::unique_ptr<VertexPositionGeometry>>(std::move(std::get<0>(lvals)),  // mesh
+                                                             std::move(std::get<1>(lvals))); // geometry
 }
 
 
@@ -37,7 +36,12 @@ std::tuple<std::unique_ptr<SurfaceMesh>, std::unique_ptr<VertexPositionGeometry>
 makeGeneralHalfedgeAndGeometry(const std::vector<std::vector<size_t>>& polygons,
                                const std::vector<std::vector<std::tuple<size_t, size_t>>>& twins,
                                const std::vector<Vector3> vertexPositions) {
-  return makeSurfaceMeshAndGeometry(polygons, twins, vertexPositions);
+
+  auto lvals = makeSurfaceMeshAndGeometry(polygons, twins, vertexPositions, {});
+
+  return std::tuple<std::unique_ptr<SurfaceMesh>,
+                    std::unique_ptr<VertexPositionGeometry>>(std::move(std::get<0>(lvals)),  // mesh
+                                                             std::move(std::get<1>(lvals))); // geometry
 }
 
 

--- a/src/surface/meshio.cpp
+++ b/src/surface/meshio.cpp
@@ -87,7 +87,11 @@ readManifoldSurfaceMesh(std::string filename, std::string type) {
   SimplePolygonMesh simpleMesh;
   simpleMesh.readMeshFromFile(filename, type, loadType);
   processLoadedMesh(simpleMesh, loadType);
-  return makeManifoldSurfaceMeshAndGeometry(simpleMesh.polygons, simpleMesh.vertexCoordinates);
+  auto lvals = makeManifoldSurfaceMeshAndGeometry(simpleMesh.polygons, simpleMesh.vertexCoordinates);
+  return std::tuple<std::unique_ptr<ManifoldSurfaceMesh>,
+         std::unique_ptr<VertexPositionGeometry>>
+     ( std::move(std::get<0>( lvals )), // mesh
+       std::move(std::get<1>( lvals )) ); // geometry
 }
 std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>
 readManifoldSurfaceMesh(std::istream& in, std::string type) {
@@ -95,9 +99,31 @@ readManifoldSurfaceMesh(std::istream& in, std::string type) {
   SimplePolygonMesh simpleMesh;
   simpleMesh.readMeshFromFile(in, type);
   processLoadedMesh(simpleMesh, loadType);
-  return makeManifoldSurfaceMeshAndGeometry(simpleMesh.polygons, simpleMesh.vertexCoordinates);
+
+  auto lvals = makeManifoldSurfaceMeshAndGeometry(simpleMesh.polygons, simpleMesh.vertexCoordinates);
+  return std::tuple<std::unique_ptr<ManifoldSurfaceMesh>,
+         std::unique_ptr<VertexPositionGeometry>>
+     ( std::move(std::get<0>( lvals )), // mesh
+       std::move(std::get<1>( lvals )) ); // geometry
 }
 
+// Load a mesh with UV coordinates, which will be stored as data at triangle
+// corners (to allow for UVs that are discontinuous across edges, e.g., at cuts)
+std::tuple<
+   std::unique_ptr<ManifoldSurfaceMesh>,
+   std::unique_ptr<VertexPositionGeometry>,
+   std::unique_ptr<CornerData<Vector2>>>
+readParameterizedManifoldSurfaceMesh(std::string filename, std::string type) {
+  std::string loadType;
+  SimplePolygonMesh simpleMesh;
+  simpleMesh.readMeshFromFile(filename, type, loadType);
+  processLoadedMesh(simpleMesh, loadType);
+  return makeManifoldSurfaceMeshAndGeometry(
+        simpleMesh.polygons,
+        {},
+        simpleMesh.vertexCoordinates,
+        simpleMesh.paramCoordinates);
+}
 
 // ======= Output =======
 

--- a/src/surface/meshio.cpp
+++ b/src/surface/meshio.cpp
@@ -89,9 +89,8 @@ readManifoldSurfaceMesh(std::string filename, std::string type) {
   processLoadedMesh(simpleMesh, loadType);
   auto lvals = makeManifoldSurfaceMeshAndGeometry(simpleMesh.polygons, simpleMesh.vertexCoordinates);
   return std::tuple<std::unique_ptr<ManifoldSurfaceMesh>,
-         std::unique_ptr<VertexPositionGeometry>>
-     ( std::move(std::get<0>( lvals )), // mesh
-       std::move(std::get<1>( lvals )) ); // geometry
+                    std::unique_ptr<VertexPositionGeometry>>(std::move(std::get<0>(lvals)),  // mesh
+                                                             std::move(std::get<1>(lvals))); // geometry
 }
 std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>
 readManifoldSurfaceMesh(std::istream& in, std::string type) {
@@ -102,27 +101,34 @@ readManifoldSurfaceMesh(std::istream& in, std::string type) {
 
   auto lvals = makeManifoldSurfaceMeshAndGeometry(simpleMesh.polygons, simpleMesh.vertexCoordinates);
   return std::tuple<std::unique_ptr<ManifoldSurfaceMesh>,
-         std::unique_ptr<VertexPositionGeometry>>
-     ( std::move(std::get<0>( lvals )), // mesh
-       std::move(std::get<1>( lvals )) ); // geometry
+                    std::unique_ptr<VertexPositionGeometry>>(std::move(std::get<0>(lvals)),  // mesh
+                                                             std::move(std::get<1>(lvals))); // geometry
 }
 
 // Load a mesh with UV coordinates, which will be stored as data at triangle
 // corners (to allow for UVs that are discontinuous across edges, e.g., at cuts)
-std::tuple<
-   std::unique_ptr<ManifoldSurfaceMesh>,
-   std::unique_ptr<VertexPositionGeometry>,
-   std::unique_ptr<CornerData<Vector2>>>
+std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>,
+           std::unique_ptr<CornerData<Vector2>>>
 readParameterizedManifoldSurfaceMesh(std::string filename, std::string type) {
   std::string loadType;
   SimplePolygonMesh simpleMesh;
   simpleMesh.readMeshFromFile(filename, type, loadType);
   processLoadedMesh(simpleMesh, loadType);
-  return makeManifoldSurfaceMeshAndGeometry(
-        simpleMesh.polygons,
-        {},
-        simpleMesh.vertexCoordinates,
-        simpleMesh.paramCoordinates);
+
+  return makeManifoldSurfaceMeshAndGeometry(simpleMesh.polygons, {}, simpleMesh.vertexCoordinates,
+                                            simpleMesh.paramCoordinates);
+}
+
+// Load a mesh with UV coordinates, which will be stored as data at triangle
+// corners (to allow for UVs that are discontinuous across edges, e.g., at cuts)
+std::tuple<std::unique_ptr<SurfaceMesh>, std::unique_ptr<VertexPositionGeometry>, std::unique_ptr<CornerData<Vector2>>>
+readParameterizedSurfaceMesh(std::string filename, std::string type) {
+  std::string loadType;
+  SimplePolygonMesh simpleMesh;
+  simpleMesh.readMeshFromFile(filename, type, loadType);
+  processLoadedMesh(simpleMesh, loadType);
+
+  return makeSurfaceMeshAndGeometry(simpleMesh.polygons, {}, simpleMesh.vertexCoordinates, simpleMesh.paramCoordinates);
 }
 
 // ======= Output =======

--- a/src/surface/surface_mesh_factories.cpp
+++ b/src/surface/surface_mesh_factories.cpp
@@ -8,22 +8,19 @@ namespace surface {
 std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>
 makeManifoldSurfaceMeshAndGeometry(const std::vector<std::vector<size_t>>& polygons,
                                    const std::vector<Vector3> vertexPositions) {
-   auto lvals = makeManifoldSurfaceMeshAndGeometry(polygons, {}, vertexPositions, {});
+  auto lvals = makeManifoldSurfaceMeshAndGeometry(polygons, {}, vertexPositions, {});
 
-   return std::tuple<std::unique_ptr<ManifoldSurfaceMesh>,
-          std::unique_ptr<VertexPositionGeometry>>
-   ( std::move(std::get<0>( lvals )), // mesh
-     std::move(std::get<1>( lvals )) ); // geometry
+  return std::tuple<std::unique_ptr<ManifoldSurfaceMesh>,
+                    std::unique_ptr<VertexPositionGeometry>>(std::move(std::get<0>(lvals)),  // mesh
+                                                             std::move(std::get<1>(lvals))); // geometry
 }
 
-std::tuple<
-   std::unique_ptr<ManifoldSurfaceMesh>,
-   std::unique_ptr<VertexPositionGeometry>,
-   std::unique_ptr<CornerData<Vector2>>>
+std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>,
+           std::unique_ptr<CornerData<Vector2>>>
 makeManifoldSurfaceMeshAndGeometry(const std::vector<std::vector<size_t>>& polygons,
                                    const std::vector<std::vector<std::tuple<size_t, size_t>>>& twins,
                                    const std::vector<Vector3> vertexPositions,
-                                   const std::vector<std::vector<Vector2>>& paramCoordinates ) {
+                                   const std::vector<std::vector<Vector2>>& paramCoordinates) {
 
   // Construct
   std::unique_ptr<ManifoldSurfaceMesh> mesh;
@@ -37,47 +34,54 @@ makeManifoldSurfaceMeshAndGeometry(const std::vector<std::vector<size_t>>& polyg
     // Use the low-level indexers here since we're constructing
     (*geometry).inputVertexPositions[v] = vertexPositions[v.getIndex()];
   }
-  std::unique_ptr<CornerData<Vector2>> parameterization( new CornerData<Vector2>(*mesh) );
-  if( paramCoordinates.size() == mesh->nFaces() )
-  {
-     for( size_t i = 0; i < mesh->nFaces(); i++ )
-     {
-        Halfedge h = mesh->face(i).halfedge();
-        for( size_t j = 0; j < paramCoordinates[i].size(); j++ )
-        {
-           (*parameterization)[h.corner()] = paramCoordinates[i][j];
-           h = h.next();
-        }
-     }
+  std::unique_ptr<CornerData<Vector2>> parameterization(new CornerData<Vector2>(*mesh));
+  if (paramCoordinates.size() == mesh->nFaces()) {
+    for (size_t i = 0; i < mesh->nFaces(); i++) {
+      Halfedge h = mesh->face(i).halfedge();
+      for (size_t j = 0; j < paramCoordinates[i].size(); j++) {
+        (*parameterization)[h.corner()] = paramCoordinates[i][j];
+        h = h.next();
+      }
+    }
   }
 
   return std::make_tuple(std::move(mesh), std::move(geometry), std::move(parameterization));
 }
 
-std::tuple<
-   std::unique_ptr<ManifoldSurfaceMesh>,
-   std::unique_ptr<VertexPositionGeometry>,
-   std::unique_ptr<CornerData<Vector2>>>
-makeParameterizedManifoldSurfaceMeshAndGeometry(
-      const std::vector<std::vector<size_t>>& polygons,
-      const std::vector<Vector3> vertexPositions,
-      const std::vector<std::vector<Vector2>>& paramCoordinates ) {
+std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>,
+           std::unique_ptr<CornerData<Vector2>>>
+makeParameterizedManifoldSurfaceMeshAndGeometry(const std::vector<std::vector<size_t>>& polygons,
+                                                const std::vector<Vector3> vertexPositions,
+                                                const std::vector<std::vector<Vector2>>& paramCoordinates) {
 
-   return makeManifoldSurfaceMeshAndGeometry(polygons, {}, vertexPositions, paramCoordinates);
+  return makeManifoldSurfaceMeshAndGeometry(polygons, {}, vertexPositions, paramCoordinates);
 }
 
 std::tuple<std::unique_ptr<SurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>
 makeSurfaceMeshAndGeometry(const std::vector<std::vector<size_t>>& polygons,
                            const std::vector<Vector3> vertexPositions) {
 
-  return makeSurfaceMeshAndGeometry(polygons, {}, vertexPositions);
+  auto lvals = makeSurfaceMeshAndGeometry(polygons, {}, vertexPositions, {});
+  return std::tuple<std::unique_ptr<SurfaceMesh>,
+                    std::unique_ptr<VertexPositionGeometry>>(std::move(std::get<0>(lvals)),  // mesh
+                                                             std::move(std::get<1>(lvals))); // geometry
+}
+
+// Like above, but with UV coordinates
+std::tuple<std::unique_ptr<SurfaceMesh>, std::unique_ptr<VertexPositionGeometry>, std::unique_ptr<CornerData<Vector2>>>
+makeParameterizedSurfaceMeshAndGeometry(const std::vector<std::vector<size_t>>& polygons,
+                                        const std::vector<Vector3> vertexPositions,
+                                        const std::vector<std::vector<Vector2>>& paramCoordinates) {
+
+  return makeSurfaceMeshAndGeometry(polygons, {}, vertexPositions, paramCoordinates);
 }
 
 
-std::tuple<std::unique_ptr<SurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>
+std::tuple<std::unique_ptr<SurfaceMesh>, std::unique_ptr<VertexPositionGeometry>, std::unique_ptr<CornerData<Vector2>>>
 makeSurfaceMeshAndGeometry(const std::vector<std::vector<size_t>>& polygons,
                            const std::vector<std::vector<std::tuple<size_t, size_t>>>& twins,
-                           const std::vector<Vector3> vertexPositions) {
+                           const std::vector<Vector3> vertexPositions,
+                           const std::vector<std::vector<Vector2>>& paramCoordinates) {
 
   // Construct
   std::unique_ptr<SurfaceMesh> mesh;
@@ -92,7 +96,18 @@ makeSurfaceMeshAndGeometry(const std::vector<std::vector<size_t>>& polygons,
     (*geometry).inputVertexPositions[v] = vertexPositions[v.getIndex()];
   }
 
-  return std::make_tuple(std::move(mesh), std::move(geometry));
+  std::unique_ptr<CornerData<Vector2>> parameterization(new CornerData<Vector2>(*mesh));
+  if (paramCoordinates.size() == mesh->nFaces()) {
+    for (size_t i = 0; i < mesh->nFaces(); i++) {
+      Halfedge h = mesh->face(i).halfedge();
+      for (size_t j = 0; j < paramCoordinates[i].size(); j++) {
+        (*parameterization)[h.corner()] = paramCoordinates[i][j];
+        h = h.next();
+      }
+    }
+  }
+
+  return std::make_tuple(std::move(mesh), std::move(geometry), std::move(parameterization));
 }
 
 


### PR DESCRIPTION
This PR adds a new method `readParameterizedManifoldSurfaceMesh()` that loads an OBJ file with UV coordinates directly into a `ManifoldSurfaceMesh` and associated `CornerData`.  It does not break compatibility with any existing methods for reading data; just adds one that loads UVs.

To implement it, I generalized the method `makeManifoldSurfaceMeshAndGeometry` to take a list of UV coordinates (with the same format produced by `SimplePolygonMesh`).  This method is the "general purpose" method, and returns a list that always includes UVs.  Other wrapper methods take a subset of the return values and return them.

Note that, internally, the mechanism for returning a subset of the return values is a bit ugly, and follows this pattern:

```
   auto lvals = makeManifoldSurfaceMeshAndGeometry(polygons, {}, vertexPositions, {});

   return std::tuple<std::unique_ptr<ManifoldSurfaceMesh>,
          std::unique_ptr<VertexPositionGeometry>>
   ( std::move(std::get<0>( lvals )), // mesh
     std::move(std::get<1>( lvals )) ); // geometry
```

However, this doesn't affect anything on the user end.