### PR TITLE
Bug..fix?

### DIFF
--- a/include/geometrycentral/surface/vector_heat_method.h
+++ b/include/geometrycentral/surface/vector_heat_method.h
@@ -37,7 +37,7 @@ public:
 
 
   // === The Logarithmic map
-  VertexData<Vector2> computeLogMap(const Vertex& sourceVert, double vertexDistanceShift = 0.);
+  VertexData<Vector2> computeLogMap(const Vertex& sourceVert, double vertexDistanceShift = 0., double vertAngleRad = 0.);
   VertexData<Vector2> computeLogMap(const SurfacePoint& sourceP);
 
 

--- a/src/surface/vector_heat_method.cpp
+++ b/src/surface/vector_heat_method.cpp
@@ -252,7 +252,7 @@ VectorHeatMethodSolver::transportTangentVectors(const std::vector<std::tuple<Sur
 }
 
 
-VertexData<Vector2> VectorHeatMethodSolver::computeLogMap(const Vertex& sourceVert, double vertexDistanceShift) {
+VertexData<Vector2> VectorHeatMethodSolver::computeLogMap(const Vertex& sourceVert, double vertexDistanceShift, double vertAngleRad) {
   geom.requireFaceAreas();
   geom.requireEdgeLengths();
   geom.requireCornerAngles();
@@ -284,7 +284,7 @@ VertexData<Vector2> VectorHeatMethodSolver::computeLogMap(const Vertex& sourceVe
 
   // Build rhs
   Vector<std::complex<double>> horizontalRHS = Vector<std::complex<double>>::Zero(mesh.nVertices());
-  horizontalRHS[geom.vertexIndices[sourceVert]] += 1.0;
+  horizontalRHS[geom.vertexIndices[sourceVert]] = -1.0 * (cos(vertAngleRad) + sin(vertAngleRad) * 1i);
 
   // Solve
   Vector<std::complex<double>> horizontalSol = vectorHeatSolver->solve(horizontalRHS);


### PR DESCRIPTION
It seems like the log map computation did not actually take the orientation of a tangent vector into account. Tried this out with the vector heat demo and this appears to adjust with the correct tangent vector propagation...but not entirely sure why the sign inversion was necessary / why the sweep started from the other side if the real axis (presumably) is oriented in the tv direction.

Adding defaulting to not make other stuff blow up :) 

Feel free to reject if unwarranted!