### PR TITLE
Implement `setMarkedEdges`

### DIFF
--- a/src/surface/intrinsic_triangulation.cpp
+++ b/src/surface/intrinsic_triangulation.cpp
@@ -53,6 +53,11 @@ IntrinsicTriangulation::IntrinsicTriangulation(ManifoldSurfaceMesh& mesh_, Intri
 
 IntrinsicTriangulation::~IntrinsicTriangulation() {}
 
+void IntrinsicTriangulation::setMarkedEdges(const EdgeData<bool>& markedEdges_) {
+  markedEdges = markedEdges_;
+  markedEdges.setDefault(false);
+}
+
 // ======================================================
 // ======== Queries & Accessors
 // ======================================================


### PR DESCRIPTION
Looks like we missed this when implementing the general intrinsic triangulation class. I just copied the function from the old signpost code