### PR TITLE
Simplification & subdivision

### DIFF
--- a/include/geometrycentral/surface/mutation_manager.h
+++ b/include/geometrycentral/surface/mutation_manager.h
@@ -128,20 +128,23 @@ public:
   // to `tSplit`.
   // In general, both the `tSplit` and the `newVertexPosition` are used; `tSplit` is necessary to allow callbacks to
   // interpolate data; if called with either the other will be inferred.
-  void splitEdge(Edge e, double tSplit);
-  void splitEdge(Edge e, Vector3 newVertexPosition);
-  void splitEdge(Edge e, double tSplit, Vector3 newVertexPosition);
+  // Returns the new halfedge which points away from the new vertex (so he.vertex() is the new vertex), and is the same
+  // direction as e.halfedge() on the original edge. The halfedge direction of the other part of the new split edge is
+  // also preserved.
+  Halfedge splitEdge(Edge e, double tSplit);
+  Halfedge splitEdge(Edge e, Vector3 newVertexPosition);
+  Halfedge splitEdge(Edge e, double tSplit, Vector3 newVertexPosition);
 
   // Collapse an edge.
-  // Returns true if the edge could actually be collapsed.
-  bool collapseEdge(Edge e, double tCollapse);
-  bool collapseEdge(Edge e, Vector3 newVertexPosition);
-  bool collapseEdge(Edge e, double tCollapse, Vector3 newVertexPosition);
+  // Returns the new vertex if the edge could be collapsed, and Vertex() otherwise
+  Vertex collapseEdge(Edge e, double tCollapse);
+  Vertex collapseEdge(Edge e, Vector3 newVertexPosition);
+  Vertex collapseEdge(Edge e, double tCollapse, Vector3 newVertexPosition);
 
-  // Split a face (i.e. insert a vertex into the face)
-  void splitFace(Face f, const std::vector<double>& bSplit);
-  void splitFace(Face f, Vector3 newVertexPosition);
-  void splitFace(Face f, const std::vector<double>& bSplit, Vector3 newVertexPosition);
+  // Split a face (i.e. insert a vertex into the face), and return the new vertex
+  Vertex splitFace(Face f, const std::vector<double>& bSplit);
+  Vertex splitFace(Face f, Vector3 newVertexPosition);
+  Vertex splitFace(Face f, const std::vector<double>& bSplit, Vector3 newVertexPosition);
 
   // ======================================================
   // ======== High-level mutations

--- a/include/geometrycentral/surface/quadric_error_simplification.h
+++ b/include/geometrycentral/surface/quadric_error_simplification.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "geometrycentral/surface/manifold_surface_mesh.h"
+#include "geometrycentral/surface/mutation_manager.h"
+#include "geometrycentral/surface/vertex_position_geometry.h"
+
+#include <queue>
+
+namespace geometrycentral {
+namespace surface {
+class Quadric {
+public:
+  Quadric();
+  Quadric(const Eigen::Matrix3d& A_, const Eigen::Vector3d& b_, double c_);
+  Quadric(const Quadric& Q1, const Quadric& Q2);
+  double cost(const Eigen::Vector3d& v);
+  Eigen::Vector3d optimalPoint();
+
+  Quadric operator+=(const Quadric& Q);
+
+protected:
+  Eigen::Matrix3d A;
+  Eigen::Vector3d b;
+  double c;
+
+  friend Quadric operator+(const Quadric& Q1, const Quadric& Q2);
+};
+
+Quadric operator+(const Quadric& Q1, const Quadric& Q2);
+
+void quadricErrorSimplify(ManifoldSurfaceMesh& mesh, VertexPositionGeometry& geo, double tol = 0.05);
+void quadricErrorSimplify(ManifoldSurfaceMesh& mesh, VertexPositionGeometry& geo, double tol = 0.05,
+                          MutationManager& mm);
+
+} // namespace surface
+} // namespace geometrycentral

--- a/include/geometrycentral/surface/quadric_error_simplification.h
+++ b/include/geometrycentral/surface/quadric_error_simplification.h
@@ -4,6 +4,8 @@
 #include "geometrycentral/surface/mutation_manager.h"
 #include "geometrycentral/surface/vertex_position_geometry.h"
 
+#include "geometrycentral/utilities/elementary_geometry.h"
+
 #include <queue>
 
 namespace geometrycentral {
@@ -29,8 +31,7 @@ protected:
 Quadric operator+(const Quadric& Q1, const Quadric& Q2);
 
 void quadricErrorSimplify(ManifoldSurfaceMesh& mesh, VertexPositionGeometry& geo, double tol = 0.05);
-void quadricErrorSimplify(ManifoldSurfaceMesh& mesh, VertexPositionGeometry& geo, double tol = 0.05,
-                          MutationManager& mm);
+void quadricErrorSimplify(ManifoldSurfaceMesh& mesh, VertexPositionGeometry& geo, double tol, MutationManager& mm);
 
 } // namespace surface
 } // namespace geometrycentral

--- a/include/geometrycentral/surface/subdivide.h
+++ b/include/geometrycentral/surface/subdivide.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "geometrycentral/surface/manifold_surface_mesh.h"
+#include "geometrycentral/surface/mutation_manager.h"
+#include "geometrycentral/surface/vertex_position_geometry.h"
+
+namespace geometrycentral {
+namespace surface {
+
+// Subdivide to form quad mesh
+// Note: these do not take MutationManager arguments since MutationManager only supports triangular meshes at the moment
+void linearSubdivide(ManifoldSurfaceMesh& mesh, VertexPositionGeometry& geo);
+void catmullClarkSubdivide(ManifoldSurfaceMesh& mesh, VertexPositionGeometry& geo);
+
+void loopSubdivide(ManifoldSurfaceMesh& mesh, VertexPositionGeometry& geo);
+void loopSubdivide(ManifoldSurfaceMesh& mesh, VertexPositionGeometry& geo, MutationManager& mm);
+
+} // namespace surface
+} // namespace geometrycentral

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,8 @@ SET(SRCS
   surface/tufted_laplacian.cpp
   surface/flip_geodesics.cpp
   surface/transfer_functions.cpp
+  surface/quadric_error_simplification.cpp
+  surface/subdivide.cpp
   #surface/detect_symmetry.cpp
   #surface/mesh_ray_tracer.cpp
   
@@ -105,6 +107,7 @@ SET(HEADERS
   ${INCLUDE_ROOT}/surface/mesh_graph_algorithms.h
   ${INCLUDE_ROOT}/surface/mesh_ray_tracer.h
   ${INCLUDE_ROOT}/surface/parameterize.h
+  ${INCLUDE_ROOT}/surface/quadric_error_simplification.h
   ${INCLUDE_ROOT}/surface/rich_surface_mesh_data.h
   ${INCLUDE_ROOT}/surface/rich_surface_mesh_data.ipp
   ${INCLUDE_ROOT}/surface/polygon_soup_mesh.h
@@ -112,6 +115,7 @@ SET(HEADERS
   ${INCLUDE_ROOT}/surface/signpost_intrinsic_triangulation.ipp
   ${INCLUDE_ROOT}/surface/simple_idt.h
   ${INCLUDE_ROOT}/surface/simple_polygon_mesh.h
+  ${INCLUDE_ROOT}/surface/subdivide.h
   ${INCLUDE_ROOT}/surface/surface_centers.h
   ${INCLUDE_ROOT}/surface/surface_mesh.h
   ${INCLUDE_ROOT}/surface/surface_mesh.ipp

--- a/src/surface/quadric_error_simplification.cpp
+++ b/src/surface/quadric_error_simplification.cpp
@@ -1,0 +1,113 @@
+#include "quadric_error_simplification.h"
+
+namespace geometrycentral {
+namespace surface {
+
+Quadric::Quadric() {
+  A = Eigen::Matrix3d::Zero();
+  b = Eigen::Vector3d::Zero();
+  c = 0;
+}
+
+Quadric::Quadric(const Quadric& Q1, const Quadric& Q2) {
+  A = Q1.A + Q2.A;
+  b = Q1.b + Q2.b;
+  c = Q1.c + Q2.c;
+}
+
+Quadric::Quadric(const Eigen::Matrix3d& A_, const Eigen::Vector3d& b_, double c_) : A(A_), b(b_), c(c_) {}
+
+double Quadric::cost(const Eigen::Vector3d& v) { return v.dot(A * v) + 2 * b.dot(v) + c; }
+
+Eigen::Vector3d Quadric::optimalPoint() { return -A.inverse() * b; }
+
+Quadric Quadric::operator+=(const Quadric& Q) {
+  A += Q.A;
+  b += Q.b;
+  c += Q.c;
+
+  return *this;
+}
+
+Quadric operator+(const Quadric& Q1, const Quadric& Q2) { return Quadric(Q1.A + Q2.A, Q1.b + Q2.b, Q1.c + Q2.c); }
+
+void quadricErrorSimplify(ManifoldSurfaceMesh& mesh, VertexPositionGeometry& geo, double tol) {
+  MutationManager mm(mesh);
+  quadricErrorSimplify(mesh, geo, tol, mm);
+}
+
+void quadricErrorSimplify(ManifoldSurfaceMesh& mesh, VertexPositionGeometry& geo, double tol, MutationManager& mm) {
+  VertexData<QES::Quadric> Q(mesh, QES::Quadric());
+
+  geo.requireFaceNormals();
+
+  for (Face f : mesh.faces()) {
+    Eigen::Vector3d n = toEigen(geo.faceNormals[f]);
+    Eigen::Matrix3d M = n * n.transpose();
+    for (Vertex v : f.adjacentVertices()) {
+      Eigen::Vector3d q = toEigen(geo.inputVertexPositions[v]);
+      double d = -n.dot(q);
+
+      Q[v] += QES::Quadric(M, d * n, d * d);
+    }
+  }
+
+  using PotentialEdge = std::tuple<double, Edge>;
+
+  auto cmp = [](const PotentialEdge& a, const PotentialEdge& b) -> bool { return std::get<0>(a) > std::get<0>(b); };
+
+  std::priority_queue<PotentialEdge, std::vector<PotentialEdge>, decltype(cmp)> edgesToCheck(cmp);
+
+  for (Edge e : mesh.edges()) {
+    QES::Quadric Qe = Q[e.src()] + Q[e.dst()];
+    Eigen::Vector3d q = Qe.optimalPoint();
+    double cost = Qe.cost(q);
+    edgesToCheck.push(std::make_tuple(cost, e));
+  }
+
+  while (!edgesToCheck.empty()) {
+    PotentialEdge best = edgesToCheck.top();
+    edgesToCheck.pop();
+
+    // Stop when collapse becomes too expensive
+    double cost = std::get<0>(best);
+    if (cost > tol) break;
+
+    Edge e = std::get<1>(best);
+    if (!e.isDead()) {
+
+      // Get edge quadric
+      QES::Quadric Qe(Q[e.src()], Q[e.dst()]);
+      Eigen::Vector3d q = Qe.optimalPoint();
+
+      // If either vertex has been collapsed since the edge was pushed
+      // onto the queue, the old cost was wrong. In that case, give up
+      if (abs(cost - Qe.cost(q)) > 1e-8) continue;
+
+      Vertex v;
+      try {
+        v = mm.collapseEdge(e);
+      } catch (std::runtime_error& e) {
+      }
+
+      // v == Vertex() if collapseEdge threw an exception, or if
+      // collapseEdge failed and returned Vertex(). In either case, we
+      // give up
+      if (v == Vertex()) continue;
+      geo.vertexPositions[v] = fromEigen(q);
+      Q[v] = Qe;
+
+      for (Edge f : v.adjacentEdges()) {
+        QES::Quadric Qf(Q[f.src()], Q[f.dst()]);
+        Eigen::Vector3d q = Qf.optimalPoint();
+        double cost = Qf.cost(q);
+        edgesToCheck.push(std::make_tuple(cost, f));
+      }
+    }
+  }
+
+  mesh.compress();
+  return;
+}
+} // namespace surface
+} // namespace geometrycentral

--- a/src/surface/subdivide.cpp
+++ b/src/surface/subdivide.cpp
@@ -1,0 +1,255 @@
+#include "geometrycentral/surface/subdivide.h"
+
+namespace geometrycentral {
+namespace surface {
+
+void linearSubdivide(ManifoldSurfaceMesh& mesh, VertexPositionGeometry& geo) {
+
+  VertexData<Vector3>& pos = geo.inputVertexPositions;
+
+  // Compute new positions for original vertices
+  VertexData<Vector3> newPositions = geo.inputVertexPositions;
+
+  FaceData<Vector3> splitFacePositions(mesh);
+  for (Face f : mesh.faces()) {
+    double D = (double)f.degree();
+    splitFacePositions[f] = Vector3::zero();
+    for (Vertex v : f.adjacentVertices()) {
+      splitFacePositions[f] += geo.inputVertexPositions[v] / D;
+    }
+  }
+
+  EdgeData<Vector3> splitEdgePositions(mesh);
+  for (Edge e : mesh.edges()) {
+    splitEdgePositions[e] = (pos[e.halfedge().tailVertex()] + pos[e.halfedge().tipVertex()]) / 2.;
+  }
+
+  // Subdivide edges
+  VertexData<bool> isOrigVert(mesh, true);
+  EdgeData<bool> isOrigEdge(mesh, true);
+  for (Edge e : mesh.edges()) {
+    if (!isOrigEdge[e]) continue;
+
+    Vector3 newPos = splitEdgePositions[e];
+
+    // split the edge
+    Halfedge newHe = mesh.insertVertexAlongEdge(e);
+    Vertex newV = newHe.vertex();
+
+    isOrigVert[newV] = false;
+    isOrigEdge[newHe.edge()] = false;
+    isOrigEdge[newHe.twin().next().edge()] = false;
+
+    GC_SAFETY_ASSERT(isOrigVert[newHe.twin().vertex()] && isOrigVert[newHe.twin().next().twin().vertex()], "???");
+
+    newPositions[newV] = newPos;
+  }
+
+  // Subdivide faces
+  FaceData<bool> isOrigFace(mesh, true);
+  for (Face f : mesh.faces()) {
+    if (!isOrigFace[f]) continue;
+
+    Vector3 newPos = splitFacePositions[f];
+
+    // split the face
+    Vertex newV = mesh.insertVertex(f);
+    isOrigVert[newV] = false;
+    newPositions[newV] = newPos;
+
+    for (Face f : newV.adjacentFaces()) {
+      isOrigFace[f] = false;
+    }
+
+    // get incoming halfedges before we start deleting edges
+    std::vector<Halfedge> incomingHalfedges;
+    for (Halfedge he : newV.incomingHalfedges()) {
+      incomingHalfedges.push_back(he);
+    }
+
+    for (Halfedge he : incomingHalfedges) {
+      if (isOrigVert[he.vertex()]) {
+        Face mergedF = mesh.removeEdge(he.edge());
+        if (mergedF == Face()) {
+          std::cout << "merge was impossible?" << std::endl;
+        } else {
+          isOrigFace[mergedF] = false;
+        }
+      }
+    }
+  }
+
+  mesh.compress();
+  geo.inputVertexPositions = newPositions;
+  geo.refreshQuantities();
+}
+
+void catmullClarkSubdivide(ManifoldSurfaceMesh& mesh, VertexPositionGeometry& geo) {
+  VertexData<Vector3>& pos = geo.inputVertexPositions;
+
+  // Compute new positions for original vertices
+  VertexData<Vector3> newPositions(mesh);
+
+  FaceData<Vector3> splitFacePositions(mesh);
+  for (Face f : mesh.faces()) {
+    double D = (double)f.degree();
+    splitFacePositions[f] = Vector3::zero();
+    for (Vertex v : f.adjacentVertices()) {
+      splitFacePositions[f] += geo.inputVertexPositions[v] / D;
+    }
+  }
+
+  EdgeData<Vector3> splitEdgePositions(mesh);
+  for (Edge e : mesh.edges()) {
+    std::array<Face, 2> neigh{e.halfedge().face(), e.halfedge().twin().face()};
+    splitEdgePositions[e] = (splitFacePositions[neigh[0]] + splitFacePositions[neigh[1]]) / 2.;
+  }
+
+  for (Vertex v : mesh.vertices()) {
+    double D = (double)v.degree();
+    Vector3 S = geo.inputVertexPositions[v];
+    Vector3 R = Vector3::zero();
+    for (Edge e : v.adjacentEdges()) {
+      R += splitEdgePositions[e] / D;
+    }
+    Vector3 Q = Vector3::zero();
+    for (Face f : v.adjacentFaces()) {
+      Q += splitFacePositions[f] / D;
+    }
+    newPositions[v] = (Q + 2 * R + (D - 3) * S) / D;
+  }
+
+  // Subdivide edges
+  VertexData<bool> isOrigVert(mesh, true);
+  EdgeData<bool> isOrigEdge(mesh, true);
+  for (Edge e : mesh.edges()) {
+    if (!isOrigEdge[e]) continue;
+
+    Vector3 newPos = splitEdgePositions[e];
+
+    // split the edge
+    Halfedge newHe = mesh.insertVertexAlongEdge(e);
+    Vertex newV = newHe.vertex();
+
+    isOrigVert[newV] = false;
+    isOrigEdge[newHe.edge()] = false;
+    isOrigEdge[newHe.twin().next().edge()] = false;
+
+    GC_SAFETY_ASSERT(isOrigVert[newHe.twin().vertex()] && isOrigVert[newHe.twin().next().twin().vertex()], "???");
+
+    newPositions[newV] = newPos;
+  }
+
+  // Subdivide faces
+  FaceData<bool> isOrigFace(mesh, true);
+  for (Face f : mesh.faces()) {
+    if (!isOrigFace[f]) continue;
+
+    Vector3 newPos = splitFacePositions[f];
+
+    // split the face
+    Vertex newV = mesh.insertVertex(f);
+    isOrigVert[newV] = false;
+    newPositions[newV] = newPos;
+
+    for (Face f : newV.adjacentFaces()) {
+      isOrigFace[f] = false;
+    }
+
+    // get incoming halfedges before we start deleting edges
+    std::vector<Halfedge> incomingHalfedges;
+    for (Halfedge he : newV.incomingHalfedges()) {
+      incomingHalfedges.push_back(he);
+    }
+
+    for (Halfedge he : incomingHalfedges) {
+      if (isOrigVert[he.vertex()]) {
+        Face mergedF = mesh.removeEdge(he.edge());
+        if (mergedF == Face()) {
+          std::cout << "merge was impossible?" << std::endl;
+        } else {
+          isOrigFace[mergedF] = false;
+        }
+      }
+    }
+  }
+
+  mesh.compress();
+  geo.inputVertexPositions = newPositions;
+  geo.refreshQuantities();
+}
+
+void loopSubdivide(ManifoldSurfaceMesh& mesh, VertexPositionGeometry& geo) {
+  MutationManager mm(mesh, geo);
+  return loopSubdivide(mesh, geo, mm);
+}
+
+void loopSubdivide(ManifoldSurfaceMesh& mesh, VertexPositionGeometry& geo, MutationManager& mm) {
+  GC_SAFETY_ASSERT(mesh.isTriangular(), "Cannot run loop subdivision on a mesh with non-triangular faces");
+
+  VertexData<Vector3>& pos = geo.inputVertexPositions;
+  VertexData<bool> isOrigVert(mesh, true);
+  EdgeData<bool> isOrigEdge(mesh, true);
+
+  // Compute new positions for original vertices
+  VertexData<Vector3> newPositions(mesh);
+  for (Vertex v : mesh.vertices()) {
+    double n = (double)v.degree();
+    double u = (n == 3) ? 3. / 16. : 3. / (8. * n);
+    newPositions[v] = (1 - n * u) * pos[v];
+    for (Vertex w : v.adjacentVertices()) {
+      newPositions[v] += u * pos[w];
+    }
+  }
+
+  EdgeData<Vector3> splitVertexPositions(mesh);
+  for (Edge e : mesh.edges()) {
+    if (e.isBoundary()) {
+      splitVertexPositions[e] = (pos[e.halfedge().tailVertex()] + pos[e.halfedge().tipVertex()]) / 2.;
+    } else {
+      std::array<Vertex, 2> ends{e.halfedge().tailVertex(), e.halfedge().tipVertex()};
+      std::array<Vertex, 2> sides{e.halfedge().next().next().vertex(), e.halfedge().twin().next().next().vertex()};
+      splitVertexPositions[e] = 3. / 8. * (pos[ends[0]] + pos[ends[1]]) + 1. / 8. * (pos[sides[0]] + pos[sides[1]]);
+    }
+  }
+
+  // Subdivide edges
+  std::vector<Edge> toFlip;
+  for (Edge e : mesh.edges()) {
+    if (!isOrigEdge[e]) continue;
+
+    // gather both vertices incident on the edge
+    Vertex oldA = e.halfedge().tipVertex();
+    Vertex oldB = e.halfedge().tailVertex();
+
+    Vector3 newPos = splitVertexPositions[e];
+
+    // split the edge
+    Vertex newV = mm.splitEdge(e, newPos).vertex();
+    isOrigVert[newV] = false;
+    newPositions[newV] = newPos;
+
+    // iterate through the edges incident on the new vertex
+    for (Edge e : newV.adjacentEdges()) {
+      isOrigEdge[e] = false;               // mark the new edges
+      Vertex otherV = e.otherVertex(newV); // other side of edge
+
+      // if this is a new edge between an old an new vertex, save for
+      // flipping
+      if (isOrigVert[otherV] && otherV != oldA && otherV != oldB) {
+        toFlip.push_back(e);
+      }
+    }
+  }
+
+  for (Edge e : toFlip) {
+    mesh.flip(e);
+  }
+
+  mesh.compress();
+  geo.inputVertexPositions = newPositions;
+  geo.refreshQuantities();
+}
+
+} // namespace surface
+} // namespace geometrycentral


### PR DESCRIPTION
I added implementations of quadric error simplification, Catmull-Clark subdivision, and Loop subdivision. Quadric error simplification and Loop subdivision optionally take a `MutationManager` argument. Unfortunately, Catmull-Clark doesn't, since `MutationManager` is tailored for triangle meshes at the moment.

I also changed `MutationManager`'s mutations to return the newly-created mesh element (i.e. `mutationManager.collapseEdge(e)` now returns the new vertex).