### PR TITLE
Intrinsic MMP

### DIFF
--- a/docs/docs/surface/algorithms/geodesic_distance.md
+++ b/docs/docs/surface/algorithms/geodesic_distance.md
@@ -37,7 +37,7 @@ VertexData<double> distToSource = exactGeodesicDistance(*mesh, *geometry, source
 
     Compute the distance from the source using MMP. See the stateful class below for further options.
     
-### Complex Queries
+### Advanced Queries
 
 The stateful class `GeodesicAlgorithmExact` runs the MMP algorithm to compute geodesic distance from a given set of source points. The resulting distance field can be queried at any point on the input mesh to find the identity of the nearest source point, the distance to the source point, and the shortest path to the source point.
 
@@ -80,6 +80,10 @@ VertexData<double> distToSource = mmp.getDistanceFunction();
 // Query the distance function at some point
 SurfacePoint queryPoint = /* some point on the surface */
 double dist = mmp.getDistance(queryPoint);
+
+// Get the geodesic path from a query point to the nearest source
+SurfacePoint queryPoint2 = /* some point on the surface */
+std::vector<SurfacePoint> path = mmp.traceBack(queryPoint2);
 ```
 
 
@@ -136,6 +140,10 @@ double dist = mmp.getDistance(queryPoint);
 ??? func "`#!cpp VertexData<double> GeodesicAlgorithmExact::getDistanceFunction()`"
 
     Evaluate the distance function at every vertex of the mesh.
+    
+??? func "`#!cpp IntervalList GeodesicAlgorithmExact::getEdgeIntervals(Edge e)`"
+
+    Get the list of windows along edge `e` that MMP uses to represent the distance function.
 
 TODO document `exact_polyhedral_geodesics.h`
 

--- a/include/geometrycentral/surface/exact_geodesic_helpers.h
+++ b/include/geometrycentral/surface/exact_geodesic_helpers.h
@@ -1,0 +1,210 @@
+// Copyright (C) 2008 Danil Kirsanov, MIT License
+
+#pragma once
+
+#include "geometrycentral/surface/barycentric_coordinate_helpers.h"
+#include "geometrycentral/surface/intrinsic_geometry_interface.h"
+#include "geometrycentral/surface/surface_point.h"
+
+#include <algorithm>
+#include <assert.h>
+#include <cmath>
+#include <vector>
+
+// added by nsharp
+#include <memory>
+#include <string.h>
+
+namespace geometrycentral {
+namespace surface {
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+// double const GEODESIC_INF = std::numeric_limits<double>::max();
+double const GEODESIC_INF = 1e100;
+
+// in order to avoid numerical problems with "infinitely small" intervals,
+// we drop all the intervals smaller than SMALLEST_INTERVAL_RATIO*edge_length
+double const SMALLEST_INTERVAL_RATIO = 1e-6;
+
+class Interval;
+class IntervalList;
+typedef Interval* interval_pointer;
+typedef IntervalList* list_pointer;
+
+// interval of the edge
+class Interval {
+public:
+  Interval(){};
+  ~Interval(){};
+
+  enum DirectionType { FROM_FACE_0, FROM_FACE_1, FROM_SOURCE, UNDEFINED_DIRECTION };
+
+  // geodesic distance function at point x
+  double signal(double x);
+
+  double max_distance(double end);
+
+  // compute min, given c,d theta, start, end.
+  void compute_min_distance(double stop);
+
+  // compare two intervals in the queue
+  bool operator()(interval_pointer const x, interval_pointer const y) const;
+
+  // return the endpoint of the interval
+  double stop();
+
+  double hypotenuse(double a, double b);
+
+  // find the point on the interval that is closest to the point (alpha, s)
+  void find_closest_point(double const x, double const y, double& offset, double& distance);
+
+  double& start() { return m_start; };
+  double& d() { return m_d; };
+  double& pseudo_x() { return m_pseudo_x; };
+  double& pseudo_y() { return m_pseudo_y; };
+  double& min() { return m_min; };
+  interval_pointer& next() { return m_next; };
+  Edge& edge() { return m_edge; };
+  double& edge_length() { return m_edge_length; };
+  DirectionType& direction() { return m_direction; };
+  bool visible_from_source() { return m_direction == FROM_SOURCE; };
+  unsigned& source_index() { return m_source_index; };
+
+  void initialize(IntrinsicGeometryInterface& geom, Edge edge, double edge_length, SurfacePoint* point = nullptr,
+                  unsigned source_index = 0);
+
+protected:
+  double m_start;    // initial point of the interval on the edge
+  double m_d;        // distance from the source to the pseudo-source
+  double m_pseudo_x; // coordinates of the pseudo-source in the local
+                     // coordinate system
+  double m_pseudo_y; // y-coordinate should be always negative
+  double m_min;      // minimum distance on the interval
+
+  interval_pointer m_next;   // pointer to the next interval in the list
+  Edge m_edge;               // edge that the interval belongs to
+  double m_edge_length = -1; // length of m_edge
+  unsigned m_source_index;   // the source it belongs to
+  DirectionType m_direction; // where the interval is coming from
+};
+
+struct IntervalWithStop : public Interval {
+public:
+  double& stop() { return m_stop; };
+
+public:
+  double m_stop;
+};
+
+// list of the of intervals of the given edge
+class IntervalList {
+public:
+  IntervalList();
+  ~IntervalList(){};
+
+  void clear();
+  void initialize(Edge e);
+
+  // returns the interval that covers the offset
+  interval_pointer covering_interval(double offset);
+
+  void find_closest_point(IntrinsicGeometryInterface& geom, const SurfacePoint point, double& offset, double& distance,
+                          interval_pointer& interval, bool verbose = false);
+
+  unsigned number_of_intervals();
+  interval_pointer last();
+  double signal(double x);
+
+  interval_pointer& first();
+  Edge& edge();
+
+public:
+  interval_pointer m_first; // pointer to the first member of the list
+  Edge m_edge;              // edge that owns this list
+};
+
+class SurfacePointWithIndex : public SurfacePoint {
+public:
+  SurfacePointWithIndex() : SurfacePoint(){};
+  SurfacePointWithIndex(const SurfacePoint& p) : SurfacePoint(p){};
+  unsigned index();
+
+  void initialize(const SurfacePoint& p, unsigned index);
+
+  // used for sorting
+  bool operator()(SurfacePointWithIndex* x, SurfacePointWithIndex* y) const;
+
+public:
+  unsigned m_index;
+};
+
+class SortedSources : public std::vector<SurfacePointWithIndex> {
+public:
+  typedef std::vector<SurfacePointWithIndex*> sorted_vector_type;
+
+public:
+  typedef sorted_vector_type::iterator sorted_iterator;
+  typedef std::pair<sorted_iterator, sorted_iterator> sorted_iterator_pair;
+
+  sorted_iterator_pair sources(const SurfacePoint& mesh_element);
+
+  // we initialize the sources by copy
+  void initialize(const std::vector<SurfacePoint>& sources);
+
+  SurfacePointWithIndex& operator[](unsigned i);
+
+public:
+  sorted_vector_type m_sorted;
+  SurfacePointWithIndex m_search_dummy; // used as a search template
+  SurfacePointWithIndex m_compare_less; // used as a compare functor
+};
+
+// Assorted helper functions
+namespace exactgeodesic {
+double compute_surface_distance(IntrinsicGeometryInterface& geom, const SurfacePoint& p1, const SurfacePoint& p2);
+
+unsigned compute_closest_vertices(SurfacePoint p, std::vector<Vertex>* storage);
+
+std::pair<double, double> compute_local_coordinates(IntrinsicGeometryInterface& geom, Edge e,
+                                                    const SurfacePoint& point);
+} // namespace exactgeodesic
+
+//== A fast and simple memory allocator
+// quickly allocates and deallocates single elements of a given type
+template <class T>
+class MemoryAllocator {
+public:
+  typedef T* pointer;
+
+  MemoryAllocator(unsigned block_size = 1024, unsigned max_number_of_blocks = 1024) {
+    reset(block_size, max_number_of_blocks);
+  }
+  ~MemoryAllocator(){};
+
+  void clear();
+
+  void reset(unsigned block_size, unsigned max_number_of_blocks);
+
+  // allocates single unit of memory
+  pointer allocate();
+
+  // allocate n units
+  void deallocate(pointer p);
+
+protected:
+  std::vector<std::vector<T>> m_storage;
+  unsigned m_block_size;           // size of a single block
+  unsigned m_max_number_of_blocks; // maximum allowed number of blocks
+  unsigned m_current_position;     // first unused element inside the current
+                                   // block
+
+  std::vector<pointer> m_deleted; // pointers to deleted elemets
+};
+
+} // namespace surface
+} // namespace geometrycentral
+
+#include "geometrycentral/surface/exact_geodesic_helpers.ipp"

--- a/include/geometrycentral/surface/exact_geodesic_helpers.h
+++ b/include/geometrycentral/surface/exact_geodesic_helpers.h
@@ -1,4 +1,5 @@
 // Copyright (C) 2008 Danil Kirsanov, MIT License
+// (Modified to work in geometry-central. Original code can be found here: https://code.google.com/p/geodesic/)
 
 #pragma once
 

--- a/include/geometrycentral/surface/exact_geodesic_helpers.ipp
+++ b/include/geometrycentral/surface/exact_geodesic_helpers.ipp
@@ -1,0 +1,56 @@
+// Copyright (C) 2008 Danil Kirsanov, MIT License
+
+namespace geometrycentral {
+namespace surface {
+
+template <class T>
+void MemoryAllocator<T>::clear() {
+  reset(m_block_size, m_max_number_of_blocks);
+}
+
+template <class T>
+void MemoryAllocator<T>::reset(unsigned block_size, unsigned max_number_of_blocks) {
+  m_block_size = block_size;
+  m_max_number_of_blocks = max_number_of_blocks;
+
+  assert(m_block_size > 0);
+  assert(m_max_number_of_blocks > 0);
+
+  m_current_position = 0;
+
+  m_storage.reserve(max_number_of_blocks);
+  m_storage.resize(1);
+  m_storage[0].resize(block_size);
+
+  m_deleted.clear();
+  m_deleted.reserve(2 * block_size);
+};
+
+template <class T>
+typename MemoryAllocator<T>::pointer MemoryAllocator<T>::allocate() {
+  pointer result;
+  if (m_deleted.empty()) {
+    if (m_current_position + 1 >= m_block_size) {
+      m_storage.push_back(std::vector<T>());
+      m_storage.back().resize(m_block_size);
+      m_current_position = 0;
+    }
+    result = &m_storage.back()[m_current_position];
+    ++m_current_position;
+  } else {
+    result = m_deleted.back();
+    m_deleted.pop_back();
+  }
+
+  return result;
+};
+
+template <class T>
+void MemoryAllocator<T>::deallocate(pointer p) {
+  if (m_deleted.size() < m_deleted.capacity()) {
+    m_deleted.push_back(p);
+  }
+};
+
+} // namespace surface
+} // namespace geometrycentral

--- a/include/geometrycentral/surface/exact_geodesic_helpers.ipp
+++ b/include/geometrycentral/surface/exact_geodesic_helpers.ipp
@@ -1,4 +1,5 @@
 // Copyright (C) 2008 Danil Kirsanov, MIT License
+// (Modified to work in geometry-central. Original code can be found here: https://code.google.com/p/geodesic/)
 
 namespace geometrycentral {
 namespace surface {

--- a/include/geometrycentral/surface/exact_geodesics.h
+++ b/include/geometrycentral/surface/exact_geodesics.h
@@ -1,0 +1,144 @@
+// Copyright (C) 2008 Danil Kirsanov, MIT License
+
+#pragma once
+
+#include "geometrycentral/surface/exact_geodesic_helpers.h"
+#include "geometrycentral/surface/intrinsic_geometry_interface.h"
+#include "geometrycentral/surface/manifold_surface_mesh.h"
+#include "geometrycentral/surface/surface_point.h"
+
+#include <assert.h>
+#include <cmath>
+#include <set>
+#include <vector>
+
+namespace geometrycentral {
+namespace surface {
+
+// One-off function to compute distance from a vertex
+VertexData<double> exactGeodesicDistance(ManifoldSurfaceMesh& mesh, IntrinsicGeometryInterface& geom, Vertex v);
+
+class GeodesicAlgorithmExact {
+public:
+  GeodesicAlgorithmExact(ManifoldSurfaceMesh& mesh_, IntrinsicGeometryInterface& geom_);
+  ~GeodesicAlgorithmExact(){};
+
+  // propagation algorithm stops after reaching the certain distance from the
+  // source or after ensuring that all the stop_points are covered
+  void propagate(const std::vector<SurfacePoint>& sources, double max_propagation_distance = GEODESIC_INF,
+                 const std::vector<SurfacePoint>& stop_points = {});
+  void propagate(const std::vector<Vertex>& sources, double max_propagation_distance = GEODESIC_INF,
+                 const std::vector<Vertex>& stop_points = {});
+  void propagate(const SurfacePoint& source, double max_propagation_distance = GEODESIC_INF,
+                 const std::vector<SurfacePoint>& stop_points = {});
+  void propagate(const Vertex& source, double max_propagation_distance = GEODESIC_INF,
+                 const std::vector<Vertex>& stop_points = {});
+
+  // trace back piecewise-linear path
+  std::vector<SurfacePoint> traceBack(const SurfacePoint& destination);
+  std::vector<SurfacePoint> traceBack(const Vertex& destination);
+
+  // quickly find what source this point belongs to and what is the distance
+  // to this source
+  std::pair<unsigned, double> closestSource(const SurfacePoint& point);
+  std::pair<unsigned, double> closestSource(const Vertex& point);
+
+  // evaluate distance function at a point
+  double getDistance(const SurfacePoint& point);
+  double getDistance(const Vertex& point);
+
+  // evaluate distance function at all vertices
+  VertexData<double> getDistanceFunction();
+
+  void print_statistics();
+
+  IntervalList getEdgeIntervals(Edge e) const;
+
+protected:
+  typedef std::set<interval_pointer, Interval> IntervalQueue;
+
+  void update_list_and_queue(list_pointer list,
+                             IntervalWithStop* candidates, // up to two candidates
+                             unsigned num_candidates);
+
+  unsigned compute_propagated_parameters(double pseudo_x, double pseudo_y,
+                                         double d, // parameters of the interval
+                                         double start,
+                                         double end,          // start/end of the interval
+                                         double alpha,        // corner angle
+                                         double L,            // length of the new edge
+                                         bool first_interval, // if it is the first interval on the edge
+                                         bool last_interval, bool turn_left, bool turn_right,
+                                         IntervalWithStop* candidates); // if it is the last interval on the edge
+
+  void construct_propagated_intervals(bool invert, Edge gc_edge,
+                                      Face gc_face, // constructs iNew from the rest of the data
+                                      IntervalWithStop* candidates, unsigned& num_candidates,
+                                      interval_pointer source_interval);
+
+  double compute_positive_intersection(double start, double pseudo_x, double pseudo_y, double sin_alpha,
+                                       double cos_alpha); // used in construct_propagated_intervals
+
+  // intersecting two intervals with up to three intervals in the end
+  unsigned intersect_intervals(interval_pointer zero, IntervalWithStop* one);
+
+  interval_pointer best_first_interval(const SurfacePoint& point, double& best_total_distance,
+                                       double& best_interval_position, unsigned& best_source_index);
+
+  bool check_stop_conditions(unsigned& index);
+
+  void clear();
+
+  list_pointer interval_list(Edge e) { return &m_edge_interval_lists[e]; };
+
+  void set_sources(const std::vector<SurfacePoint>& sources) { m_sources.initialize(sources); }
+
+  void initialize_propagation_data();
+
+  // used in initialization
+  void list_edges_visible_from_source(SurfacePoint& source, std::vector<Edge>& storage);
+
+  long visible_from_source(SurfacePoint& point); // used in backtracing
+
+  void best_point_on_the_edge_set(SurfacePoint& point, std::vector<Edge> const& storage,
+                                  interval_pointer& best_interval, double& best_total_distance,
+                                  double& best_interval_position, bool verbose = false);
+
+  void possible_traceback_edges(SurfacePoint& point, std::vector<Edge>& storage);
+
+  bool erase_from_queue(interval_pointer p);
+
+  void set_stop_conditions(const std::vector<SurfacePoint>& stop_points, double stop_distance);
+  double stop_distance() { return m_max_propagation_distance; }
+
+  //== Data
+  typedef std::pair<Vertex, double> stop_vertex_with_distace_type;
+  // algorithm stops propagation after covering certain vertices
+  std::vector<stop_vertex_with_distace_type> m_stop_vertices;
+  double m_max_propagation_distance; // or reaching the certain distance
+
+  ManifoldSurfaceMesh& mesh;
+  IntrinsicGeometryInterface& geom;
+
+  double m_time_consumed;                // how much time does the propagation step takes
+  double m_propagation_distance_stopped; // at what distance (if any) the
+                                         // propagation algorithm stopped
+
+  IntervalQueue m_queue; // interval queue
+
+  MemoryAllocator<Interval> m_memory_allocator; // quickly allocate and deallocate intervals
+  EdgeData<IntervalList> m_edge_interval_lists; // every edge has its interval data
+
+  enum MapType { OLD, NEW }; // used for interval intersection
+  MapType map[5];
+  double start[6];
+  interval_pointer i_new[5];
+
+  size_t m_queue_max_size; // used for statistics
+  size_t m_iterations;     // used for statistics
+
+  SortedSources m_sources;
+};
+
+} // namespace surface
+} // namespace geometrycentral

--- a/include/geometrycentral/surface/exact_geodesics.h
+++ b/include/geometrycentral/surface/exact_geodesics.h
@@ -1,4 +1,5 @@
 // Copyright (C) 2008 Danil Kirsanov, MIT License
+// (Modified to work in geometry-central. Original code can be found here: https://code.google.com/p/geodesic/)
 
 #pragma once
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,8 @@ SET(SRCS
   surface/base_geometry_interface.cpp
   surface/intrinsic_geometry_interface.cpp
   surface/extrinsic_geometry_interface.cpp
+  surface/exact_geodesic_helpers.cpp
+  surface/exact_geodesics.cpp
   surface/embedded_geometry_interface.cpp
   surface/edge_length_geometry.cpp
   surface/vertex_position_geometry.cpp
@@ -90,6 +92,9 @@ SET(HEADERS
   ${INCLUDE_ROOT}/surface/edge_length_geometry.h
   ${INCLUDE_ROOT}/surface/edge_length_geometry.ipp
   ${INCLUDE_ROOT}/surface/embedded_geometry_interface.h
+  ${INCLUDE_ROOT}/surface/exact_geodesics.h
+  ${INCLUDE_ROOT}/surface/exact_geodesic_helpers.h
+  ${INCLUDE_ROOT}/surface/exact_geodesic_helpers.ipp
   ${INCLUDE_ROOT}/surface/exact_polyhedral_geodesics.h
   ${INCLUDE_ROOT}/surface/extrinsic_geometry_interface.h
   ${INCLUDE_ROOT}/surface/fast_marching_method.h

--- a/src/surface/exact_geodesic_helpers.cpp
+++ b/src/surface/exact_geodesic_helpers.cpp
@@ -1,0 +1,361 @@
+// Copyright (C) 2008 Danil Kirsanov, MIT License
+
+#include "geometrycentral/surface/exact_geodesic_helpers.h"
+
+namespace geometrycentral {
+namespace surface {
+double Interval::signal(double x) {
+  assert(x >= 0.0 && x <= m_edge_length);
+
+  if (m_d == GEODESIC_INF) {
+    return GEODESIC_INF;
+  } else {
+    double dx = x - m_pseudo_x;
+    if (m_pseudo_y == 0.0) {
+      return m_d + std::abs(dx);
+    } else {
+      return m_d + sqrt(dx * dx + m_pseudo_y * m_pseudo_y);
+    }
+  }
+}
+
+double Interval::max_distance(double end) {
+  if (m_d == GEODESIC_INF) {
+    return GEODESIC_INF;
+  } else {
+    double a = std::abs(m_start - m_pseudo_x);
+    double b = std::abs(end - m_pseudo_x);
+
+    return a > b ? m_d + sqrt(a * a + m_pseudo_y * m_pseudo_y) : m_d + sqrt(b * b + m_pseudo_y * m_pseudo_y);
+  }
+}
+
+void Interval::compute_min_distance(double stop) {
+  assert(stop > m_start);
+
+  if (m_d == GEODESIC_INF) {
+    m_min = GEODESIC_INF;
+  } else if (m_start > m_pseudo_x) {
+    m_min = signal(m_start);
+  } else if (stop < m_pseudo_x) {
+    m_min = signal(stop);
+  } else {
+    assert(m_pseudo_y <= 0);
+    m_min = m_d - m_pseudo_y;
+  }
+}
+
+bool Interval::operator()(interval_pointer const x, interval_pointer const y) const {
+  if (x->min() != y->min()) {
+    return x->min() < y->min();
+  } else if (x->start() != y->start()) {
+    return x->start() < y->start();
+  } else {
+    return x->edge() < y->edge();
+  }
+}
+
+double Interval::stop() { return m_next ? m_next->start() : m_edge_length; }
+
+double Interval::hypotenuse(double a, double b) { return sqrt(a * a + b * b); }
+
+void Interval::find_closest_point(double const rs, double const hs, double& r, double& d_out) {
+  if (m_d == GEODESIC_INF) {
+    r = GEODESIC_INF;
+    d_out = GEODESIC_INF;
+    return;
+  }
+
+  double hc = -m_pseudo_y;
+  double rc = m_pseudo_x;
+  double end = stop();
+
+  double local_epsilon = SMALLEST_INTERVAL_RATIO * m_edge_length;
+  if (std::abs(hs + hc) < local_epsilon) {
+    if (rs <= m_start) {
+      r = m_start;
+      d_out = signal(m_start) + std::abs(rs - m_start);
+    } else if (rs >= end) {
+      r = end;
+      d_out = signal(end) + fabs(end - rs);
+    } else {
+      r = rs;
+      d_out = signal(rs);
+    }
+  } else {
+    double ri = (rs * hc + hs * rc) / (hs + hc);
+
+    if (ri < m_start) {
+      r = m_start;
+      d_out = signal(m_start) + hypotenuse(m_start - rs, hs);
+    } else if (ri > end) {
+      r = end;
+      d_out = signal(end) + hypotenuse(end - rs, hs);
+    } else {
+      r = ri;
+      d_out = m_d + hypotenuse(rc - rs, hc + hs);
+    }
+  }
+}
+
+void Interval::initialize(IntrinsicGeometryInterface& geom, Edge edge, double edge_length, SurfacePoint* source,
+                          unsigned source_index) {
+  m_next = nullptr;
+  // m_geodesic_previous = nullptr;
+  m_direction = UNDEFINED_DIRECTION;
+  m_edge = edge;
+  m_edge_length = edge_length;
+  m_source_index = source_index;
+
+  m_start = 0.0;
+  // m_stop = m_edge_length;
+  if (!source) {
+    m_d = GEODESIC_INF;
+    m_min = GEODESIC_INF;
+    return;
+  }
+  m_d = 0;
+
+  if (source->type == SurfacePointType::Vertex) {
+    if (source->vertex == edge.halfedge().tailVertex()) {
+      m_pseudo_x = 0.0;
+      m_pseudo_y = 0.0;
+      m_min = 0.0;
+      return;
+    } else if (source->vertex == edge.halfedge().tipVertex()) {
+      m_pseudo_x = stop();
+      m_pseudo_y = 0.0;
+      m_min = 0.0;
+      return;
+    }
+  }
+
+  std::tie(m_pseudo_x, m_pseudo_y) = exactgeodesic::compute_local_coordinates(geom, edge, *source);
+  // edge->local_coordinates(source, m_pseudo_x, m_pseudo_y);
+  m_pseudo_y = -m_pseudo_y;
+
+  compute_min_distance(stop());
+}
+
+IntervalList::IntervalList() { m_first = nullptr; }
+void IntervalList::clear() { m_first = nullptr; };
+
+void IntervalList::initialize(Edge e) {
+  m_edge = e;
+  m_first = nullptr;
+};
+
+interval_pointer IntervalList::covering_interval(double offset) {
+  assert(m_first == nullptr || (offset >= 0.0 && offset <= m_first->edge_length()));
+
+  interval_pointer p = m_first;
+  while (p && p->stop() < offset) {
+    p = p->next();
+  }
+
+  return p; // && p->start() <= offset ? p : nullptr;
+};
+
+void IntervalList::find_closest_point(IntrinsicGeometryInterface& geom, const SurfacePoint point, double& offset,
+                                      double& distance, interval_pointer& interval, bool verbose) {
+  interval_pointer p = m_first;
+  distance = GEODESIC_INF;
+  interval = nullptr;
+
+  double x, y;
+  std::tie(x, y) = exactgeodesic::compute_local_coordinates(geom, m_edge, point);
+  if (verbose) {
+    std::cout << "\t local point coordinates are " << x << ", " << y << std::endl;
+  }
+
+  while (p) {
+    if (p->min() < GEODESIC_INF) {
+      double o, d;
+      p->find_closest_point(x, y, o, d);
+      if (d < distance) {
+        distance = d;
+        offset = o;
+        interval = p;
+        // if (verbose) {
+        //     std::cout << "\t\t new min interval!" << std::endl;
+        // }
+      }
+    }
+    p = p->next();
+  }
+};
+
+unsigned IntervalList::number_of_intervals() {
+  interval_pointer p = m_first;
+  unsigned count = 0;
+  while (p) {
+    ++count;
+    p = p->next();
+  }
+  return count;
+}
+
+interval_pointer IntervalList::last() {
+  interval_pointer p = m_first;
+  if (p) {
+    while (p->next()) {
+      p = p->next();
+    }
+  }
+  return p;
+}
+
+double IntervalList::signal(double x) {
+  interval_pointer interval = covering_interval(x);
+
+  return interval ? interval->signal(x) : GEODESIC_INF;
+}
+interval_pointer& IntervalList::first() { return m_first; };
+Edge& IntervalList::edge() { return m_edge; };
+
+unsigned SurfacePointWithIndex::index() { return m_index; }
+void SurfacePointWithIndex::initialize(const SurfacePoint& p, unsigned index) {
+  type = p.type;
+  vertex = p.vertex;
+  edge = p.edge;
+  tEdge = p.tEdge;
+  face = p.face;
+  faceCoords = p.faceCoords;
+  m_index = index;
+}
+
+bool SurfacePointWithIndex::operator()(SurfacePointWithIndex* x, SurfacePointWithIndex* y) const {
+  if (x->type != y->type) {
+    return x->type < y->type;
+  } else {
+    switch (x->type) {
+    case SurfacePointType::Vertex:
+      return x->vertex.getIndex() < y->vertex.getIndex();
+    case SurfacePointType::Edge:
+      return x->edge.getIndex() < y->edge.getIndex();
+    case SurfacePointType::Face:
+      return x->face.getIndex() < y->face.getIndex();
+    }
+  }
+}
+
+SortedSources::sorted_iterator_pair SortedSources::sources(const SurfacePoint& mesh_element) {
+  m_search_dummy = SurfacePointWithIndex(mesh_element);
+
+  return equal_range(m_sorted.begin(), m_sorted.end(), &m_search_dummy, m_compare_less);
+}
+
+void SortedSources::initialize(const std::vector<SurfacePoint>& sources) {
+  resize(sources.size());
+  m_sorted.resize(sources.size());
+  for (unsigned i = 0; i < sources.size(); ++i) {
+    SurfacePointWithIndex& p = *(begin() + i);
+
+    p.initialize(sources[i], i);
+    m_sorted[i] = &p;
+  }
+
+  std::sort(m_sorted.begin(), m_sorted.end(), m_compare_less);
+}
+
+SurfacePointWithIndex& SortedSources::operator[](unsigned i) {
+  assert(i < size());
+  return *(begin() + i);
+}
+
+
+namespace exactgeodesic {
+double compute_surface_distance(IntrinsicGeometryInterface& geom, const SurfacePoint& p1, const SurfacePoint& p2) {
+  Face fShared = sharedFace(p1, p2);
+
+  GC_SAFETY_ASSERT(fShared != Face(), "compute_surface_distance() err: Point " + std::to_string(p1) +
+                                          " not adjacent to " + std::to_string(p2));
+
+  SurfacePoint p1InFace = p1.inFace(fShared);
+  SurfacePoint p2InFace = p2.inFace(fShared);
+
+  // lengths[i] is the length of the edge opposite the i'th vertex
+  Vector3 triangleLengths{geom.edgeLengths[fShared.halfedge().next().edge()],
+                          geom.edgeLengths[fShared.halfedge().next().next().edge()],
+                          geom.edgeLengths[fShared.halfedge().edge()]};
+  Vector3 displacement = p1InFace.faceCoords - p2InFace.faceCoords;
+  return displacementLength(displacement, triangleLengths);
+}
+
+unsigned compute_closest_vertices(SurfacePoint p, std::vector<Vertex>* storage) {
+
+  switch (p.type) {
+  case SurfacePointType::Vertex: {
+    if (storage) {
+      storage->push_back(p.vertex);
+    }
+    return 1;
+  }
+  case SurfacePointType::Edge: {
+    Edge e = p.edge;
+    Halfedge he = e.halfedge();
+
+    if (storage) {
+      storage->push_back(he.tailVertex());
+      storage->push_back(he.tipVertex());
+      storage->push_back(he.next().tipVertex());
+      if (!e.isBoundary()) {
+        storage->push_back(he.twin().next().tipVertex());
+      }
+    }
+    return e.isBoundary() ? 3 : 4;
+  }
+  case SurfacePointType::Face: {
+    if (storage) {
+      for (Vertex v : p.face.adjacentVertices()) {
+        storage->push_back(v);
+      }
+    }
+    return 3;
+  }
+  }
+
+  GC_SAFETY_ASSERT(false, "this should not be reachable");
+  return 0;
+}
+
+std::pair<double, double> compute_local_coordinates(IntrinsicGeometryInterface& geom, Edge e,
+                                                    const SurfacePoint& point) {
+  SurfacePoint eDummyPt(e, 0.5);
+  Face fShared = sharedFace(point, eDummyPt);
+
+  GC_SAFETY_ASSERT(fShared != Face(), "compute_local_coordinates() err: Point " + std::to_string(point) +
+                                          " not adjacent to " + std::to_string(e));
+
+  Halfedge he = e.halfedge();
+
+  SurfacePoint pointInFace = point.inFace(fShared);
+  SurfacePoint tailInFace = SurfacePoint(he, 0).inFace(fShared);
+  SurfacePoint tipInFace = SurfacePoint(he, 1).inFace(fShared);
+
+  // lengths[i] is the length of the edge opposite the i'th vertex
+  Vector3 triangleLengths{geom.edgeLengths[fShared.halfedge().next().edge()],
+                          geom.edgeLengths[fShared.halfedge().next().next().edge()],
+                          geom.edgeLengths[fShared.halfedge().edge()]};
+  Vector3 tailDisp = pointInFace.faceCoords - tailInFace.faceCoords;
+  double d0 = displacementLength(tailDisp, triangleLengths);
+
+  if (d0 < 1e-50) {
+    return std::make_pair(0, 0);
+  }
+
+  Vector3 tipDisp = pointInFace.faceCoords - tipInFace.faceCoords;
+  double d1 = displacementLength(tipDisp, triangleLengths);
+  if (d1 < 1e-50) {
+    return std::make_pair(geom.edgeLengths[e], 0);
+  }
+
+  double x = geom.edgeLengths[e] / 2.0 + (d0 * d0 - d1 * d1) / (2.0 * geom.edgeLengths[e]);
+  double y = sqrt(std::max(0.0, d0 * d0 - x * x));
+
+  return std::make_pair(x, y);
+}
+} // namespace exactgeodesic
+
+} // namespace surface
+} // namespace geometrycentral

--- a/src/surface/exact_geodesic_helpers.cpp
+++ b/src/surface/exact_geodesic_helpers.cpp
@@ -237,6 +237,9 @@ bool SurfacePointWithIndex::operator()(SurfacePointWithIndex* x, SurfacePointWit
     case SurfacePointType::Face:
       return x->face.getIndex() < y->face.getIndex();
     }
+
+    GC_SAFETY_ASSERT(false, "this should be unreachable");
+    return false;
   }
 }
 

--- a/src/surface/exact_geodesic_helpers.cpp
+++ b/src/surface/exact_geodesic_helpers.cpp
@@ -1,4 +1,5 @@
 // Copyright (C) 2008 Danil Kirsanov, MIT License
+// (Modified to work in geometry-central. Original code can be found here: https://code.google.com/p/geodesic/)
 
 #include "geometrycentral/surface/exact_geodesic_helpers.h"
 

--- a/src/surface/exact_geodesics.cpp
+++ b/src/surface/exact_geodesics.cpp
@@ -1,4 +1,5 @@
 // Copyright (C) 2008 Danil Kirsanov, MIT License
+// (Modified to work in geometry-central. Original code can be found here: https://code.google.com/p/geodesic/)
 
 #include "geometrycentral/surface/exact_geodesics.h"
 
@@ -34,7 +35,7 @@ void GeodesicAlgorithmExact::propagate(const std::vector<Vertex>& sources, doubl
 void GeodesicAlgorithmExact::propagate(const SurfacePoint& source, double max_propagation_distance,
                                        const std::vector<SurfacePoint>& stop_points) {
   // Call general version
-  return propagate({source}, max_propagation_distance, stop_points);
+  return propagate(std::vector<SurfacePoint>{source}, max_propagation_distance, stop_points);
 }
 void GeodesicAlgorithmExact::propagate(const Vertex& source, double max_propagation_distance,
                                        const std::vector<Vertex>& stop_points) {
@@ -47,15 +48,15 @@ void GeodesicAlgorithmExact::propagate(const Vertex& source, double max_propagat
 
 std::vector<SurfacePoint> GeodesicAlgorithmExact::traceBack(const Vertex& destination) {
   // Call general version
-  return traceBack(SurfacePoint(v));
+  return traceBack(SurfacePoint(destination));
 }
 
-std::pair<unsigned, double> GeodesicAlgorithmExact::closestSource(const Vertex& point) {
+std::pair<unsigned, double> GeodesicAlgorithmExact::closestSource(const Vertex& v) {
   // Call general version
   return closestSource(SurfacePoint(v));
 }
 
-double GeodesicAlgorithmExact::getDistance(const Vertex& point) {
+double GeodesicAlgorithmExact::getDistance(const Vertex& v) {
   // Call general version
   return getDistance(SurfacePoint(v));
 }

--- a/src/surface/exact_geodesics.cpp
+++ b/src/surface/exact_geodesics.cpp
@@ -1,0 +1,1239 @@
+// Copyright (C) 2008 Danil Kirsanov, MIT License
+
+#include "geometrycentral/surface/exact_geodesics.h"
+
+namespace geometrycentral {
+namespace surface {
+
+VertexData<double> exactGeodesicDistance(ManifoldSurfaceMesh& mesh, IntrinsicGeometryInterface& geom, Vertex v) {
+  GeodesicAlgorithmExact mmp(mesh, geom);
+  mmp.propagate({SurfacePoint(v)});
+  return mmp.getDistanceFunction();
+}
+
+GeodesicAlgorithmExact::GeodesicAlgorithmExact(ManifoldSurfaceMesh& mesh_, IntrinsicGeometryInterface& geom_)
+    : m_max_propagation_distance(1e100), mesh(mesh_), geom(geom_), m_memory_allocator(mesh_.nEdges(), mesh_.nEdges()) {
+
+  geom.requireEdgeLengths();
+
+  m_edge_interval_lists = EdgeData<IntervalList>(mesh);
+  for (Edge e : mesh.edges()) {
+    m_edge_interval_lists[e].initialize(e);
+  }
+};
+
+// == Adapters for various input types
+void GeodesicAlgorithmExact::propagate(const std::vector<Vertex>& sources, double max_propagation_distance,
+                                       const std::vector<Vertex>& stop_points) {
+  // Call general version
+  std::vector<SurfacePoint> source_surface_points, stop_surface_points;
+  for (const Vertex v : sources) source_surface_points.push_back(SurfacePoint(v));
+  for (const Vertex v : stop_points) stop_surface_points.push_back(SurfacePoint(v));
+  propagate(source_surface_points, max_propagation_distance, stop_surface_points);
+}
+void GeodesicAlgorithmExact::propagate(const SurfacePoint& source, double max_propagation_distance,
+                                       const std::vector<SurfacePoint>& stop_points) {
+  // Call general version
+  return propagate({source}, max_propagation_distance, stop_points);
+}
+void GeodesicAlgorithmExact::propagate(const Vertex& source, double max_propagation_distance,
+                                       const std::vector<Vertex>& stop_points) {
+  // Call general version
+  std::vector<SurfacePoint> source_surface_points{SurfacePoint(source)};
+  std::vector<SurfacePoint> stop_surface_points;
+  for (const Vertex v : stop_points) stop_surface_points.push_back(SurfacePoint(v));
+  propagate(source_surface_points, max_propagation_distance, stop_surface_points);
+}
+
+std::vector<SurfacePoint> GeodesicAlgorithmExact::traceBack(const Vertex& destination) {
+  // Call general version
+  return traceBack(SurfacePoint(v));
+}
+
+std::pair<unsigned, double> GeodesicAlgorithmExact::closestSource(const Vertex& point) {
+  // Call general version
+  return closestSource(SurfacePoint(v));
+}
+
+double GeodesicAlgorithmExact::getDistance(const Vertex& point) {
+  // Call general version
+  return getDistance(SurfacePoint(v));
+}
+
+void GeodesicAlgorithmExact::best_point_on_the_edge_set(SurfacePoint& point, std::vector<Edge> const& storage,
+                                                        interval_pointer& best_interval, double& best_total_distance,
+                                                        double& best_interval_position, bool verbose) {
+
+  best_total_distance = 1e100;
+  for (Edge e : storage) {
+    if (verbose) {
+      std::cout << "\tconsidering edge " << e << std::endl;
+    }
+    list_pointer list = interval_list(e);
+
+    double offset;
+    double distance;
+    interval_pointer interval;
+
+    list->find_closest_point(geom, point, offset, distance, interval, verbose);
+
+    if (distance < best_total_distance) {
+      best_interval = interval;
+      best_total_distance = distance;
+      best_interval_position = offset;
+    }
+  }
+}
+
+void GeodesicAlgorithmExact::possible_traceback_edges(SurfacePoint& point, std::vector<Edge>& storage) {
+  storage.clear();
+
+  switch (point.type) {
+  case SurfacePointType::Vertex: {
+    Vertex v = point.vertex;
+    for (Halfedge he : v.outgoingHalfedges()) {
+      storage.push_back(he.next().edge());
+    }
+    break;
+  }
+  case SurfacePointType::Edge: {
+    Halfedge he = point.edge.halfedge();
+    storage.push_back(he.next().edge());
+    storage.push_back(he.next().next().edge());
+    storage.push_back(he.twin().next().edge());
+    storage.push_back(he.twin().next().next().edge());
+    break;
+  }
+  case SurfacePointType::Face: {
+    Face f = point.face;
+    for (Edge e : f.adjacentEdges()) {
+      storage.push_back(e);
+    }
+    break;
+  }
+  }
+}
+
+
+long GeodesicAlgorithmExact::visible_from_source(SurfacePoint& point) // negative if not visible
+{
+  // TODO: interesting branches still untested
+  switch (point.type) {
+  case SurfacePointType::Vertex: {
+    Vertex v = point.vertex;
+    for (Edge e : v.adjacentEdges()) {
+      list_pointer list = interval_list(e);
+
+      double edgeLength = geom.edgeLengths[e];
+      double position = e.halfedge().tailVertex() == v ? 0.0 : edgeLength;
+
+      interval_pointer interval = list->covering_interval(position);
+      if (interval && interval->visible_from_source()) {
+        return (long)interval->source_index();
+      }
+    }
+    return -1;
+  }
+  case SurfacePointType::Edge: {
+    Edge e = point.edge;
+    list_pointer list = interval_list(e);
+
+    Vertex gcTail = e.halfedge().tailVertex();
+
+    // TODO: extrinsic distance
+    double edgeLength = geom.edgeLengths[e];
+    double position = std::min(exactgeodesic::compute_surface_distance(geom, point, gcTail), edgeLength);
+
+    interval_pointer interval = list->covering_interval(position);
+    // assert(interval);
+    if (interval && interval->visible_from_source()) {
+      return (long)interval->source_index();
+    } else {
+      return -1;
+    }
+  }
+  case SurfacePointType::Face: {
+    return -1;
+  }
+  }
+
+  GC_SAFETY_ASSERT(false, "This should be unreachable");
+  return 0;
+}
+
+double GeodesicAlgorithmExact::compute_positive_intersection(double start, double pseudo_x, double pseudo_y,
+                                                             double sin_alpha, double cos_alpha) {
+  assert(pseudo_y < 0);
+
+  double denominator = sin_alpha * (pseudo_x - start) - cos_alpha * pseudo_y;
+  if (denominator < 0.0) {
+    return -1.0;
+  }
+
+  double numerator = -pseudo_y * start;
+
+  if (numerator < 1e-30) {
+    return 0.0;
+  }
+
+  if (denominator < 1e-30) {
+    return -1.0;
+  }
+
+  return numerator / denominator;
+}
+
+void GeodesicAlgorithmExact::list_edges_visible_from_source(SurfacePoint& source, std::vector<Edge>& storage) {
+
+  switch (source.type) {
+  case SurfacePointType::Vertex: {
+    Vertex v = source.vertex;
+    for (Edge e : v.adjacentEdges()) {
+      storage.push_back(e);
+    }
+    return;
+  }
+  case SurfacePointType::Edge: {
+    Edge e = source.edge;
+    storage.push_back(e);
+    return;
+  }
+  case SurfacePointType::Face: {
+    Face f = source.face;
+    for (Edge e : f.adjacentEdges()) {
+      storage.push_back(e);
+    }
+    return;
+  }
+  }
+  GC_SAFETY_ASSERT(false, "This should be unreachable");
+}
+
+bool GeodesicAlgorithmExact::erase_from_queue(interval_pointer p) {
+  if (p->min() < GEODESIC_INF / 10.0) // && p->min >= queue->begin()->first)
+  {
+    assert(m_queue.count(p) <= 1); // the set is unique
+
+    IntervalQueue::iterator it = m_queue.find(p);
+
+    if (it != m_queue.end()) {
+      m_queue.erase(it);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+unsigned GeodesicAlgorithmExact::intersect_intervals(
+    interval_pointer zero,
+    IntervalWithStop* one) // intersecting two intervals with up to three intervals in the end
+{
+  assert(zero->edge() == one->edge());
+  assert(zero->stop() > one->start() && zero->start() < one->stop());
+  assert(one->min() < GEODESIC_INF / 10.0);
+
+  double const local_epsilon = SMALLEST_INTERVAL_RATIO * one->edge_length();
+
+  unsigned N = 0;
+  if (zero->min() > GEODESIC_INF / 10.0) {
+    start[0] = zero->start();
+    if (zero->start() < one->start() - local_epsilon) {
+      map[0] = OLD;
+      start[1] = one->start();
+      map[1] = NEW;
+      N = 2;
+    } else {
+      map[0] = NEW;
+      N = 1;
+    }
+
+    if (zero->stop() > one->stop() + local_epsilon) {
+      map[N] = OLD; //"zero" interval
+      start[N++] = one->stop();
+    }
+
+    start[N + 1] = zero->stop();
+    return N;
+  }
+
+  double const local_small_epsilon = 1e-8 * one->edge_length();
+
+  double D = zero->d() - one->d();
+  double x0 = zero->pseudo_x();
+  double x1 = one->pseudo_x();
+  double R0 = x0 * x0 + zero->pseudo_y() * zero->pseudo_y();
+  double R1 = x1 * x1 + one->pseudo_y() * one->pseudo_y();
+
+  double inter[2]; // points of intersection
+  int Ninter = 0;  // number of the points of the intersection
+
+  if (std::abs(D) < local_epsilon) // if d1 == d0, equation is linear
+  {
+    double denom = x1 - x0;
+    if (std::abs(denom) > local_small_epsilon) {
+      inter[0] = (R1 - R0) / (2. * denom); // one solution
+      Ninter = 1;
+    }
+  } else {
+    double D2 = D * D;
+    double Q = 0.5 * (R1 - R0 - D2);
+    double X = x0 - x1;
+
+    double A = X * X - D2;
+    double B = Q * X + D2 * x0;
+    double C = Q * Q - D2 * R0;
+
+    if (std::abs(A) < local_small_epsilon) // if A == 0, linear equation
+    {
+      if (std::abs(B) > local_small_epsilon) {
+        inter[0] = -C / B; // one solution
+        Ninter = 1;
+      }
+    } else {
+      double det = B * B - A * C;
+      if (det > local_small_epsilon * local_small_epsilon) // two roots
+      {
+        det = sqrt(det);
+        if (A > 0.0) // make sure that the roots are ordered
+        {
+          inter[0] = (-B - det) / A;
+          inter[1] = (-B + det) / A;
+        } else {
+          inter[0] = (-B + det) / A;
+          inter[1] = (-B - det) / A;
+        }
+
+        if (inter[1] - inter[0] > local_small_epsilon) {
+          Ninter = 2;
+        } else {
+          Ninter = 1;
+        }
+      } else if (det >= 0.0) // single root
+      {
+        inter[0] = -B / A;
+        Ninter = 1;
+      }
+    }
+  }
+  //---------------------------find possible
+  // intervals---------------------------------------
+  double left = std::max(zero->start(),
+                         one->start()); // define left and right boundaries of
+                                        // the intersection of the intervals
+  double right = std::min(zero->stop(), one->stop());
+
+  double good_start[4]; // points of intersection within the (left, right)
+                        // limits +"left" + "right"
+  good_start[0] = left;
+  int Ngood_start = 1; // number of the points of the intersection
+
+  for (int i = 0; i < Ninter; ++i) // for all points of intersection
+  {
+    double x = inter[i];
+    if (x > left + local_epsilon && x < right - local_epsilon) {
+      good_start[Ngood_start++] = x;
+    }
+  }
+  good_start[Ngood_start++] = right;
+
+  MapType mid_map[3];
+  for (int i = 0; i < Ngood_start - 1; ++i) {
+    double mid = (good_start[i] + good_start[i + 1]) * 0.5;
+    mid_map[i] = zero->signal(mid) <= one->signal(mid) ? OLD : NEW;
+  }
+
+  //-----------------------------------output----------------------------------
+  N = 0;
+  if (zero->start() < left - local_epsilon) // additional "zero" interval
+  {
+    if (mid_map[0] == OLD) // first interval in the map is already the old one
+    {
+      good_start[0] = zero->start();
+    } else {
+      map[N] = OLD; //"zero" interval
+      start[N++] = zero->start();
+    }
+  }
+
+  for (long i = 0; i < Ngood_start - 1; ++i) // for all intervals
+  {
+    MapType current_map = mid_map[i];
+    if (N == 0 || map[N - 1] != current_map) {
+      map[N] = current_map;
+      start[N++] = good_start[i];
+    }
+  }
+
+  if (zero->stop() > one->stop() + local_epsilon) {
+    if (N == 0 || map[N - 1] == NEW) {
+      map[N] = OLD; //"zero" interval
+      start[N++] = one->stop();
+    }
+  }
+
+  start[0] = zero->start(); // just to make sure that epsilons do not damage anything
+  // start[N] = zero->stop();
+
+  return N;
+}
+
+void GeodesicAlgorithmExact::initialize_propagation_data() {
+  clear();
+
+  IntervalWithStop candidate;
+  std::vector<Edge> edges_visible_from_source;
+  for (unsigned i = 0; i < m_sources.size(); ++i) // for all edges adjacent to the starting vertex
+  {
+    SurfacePoint* source = &m_sources[i];
+
+    edges_visible_from_source.clear();
+    list_edges_visible_from_source(*source, edges_visible_from_source);
+
+    for (Edge e : edges_visible_from_source) {
+      double edge_length = geom.edgeLengths[e];
+      candidate.initialize(geom, e, edge_length, source, i);
+      candidate.stop() = edge_length;
+      candidate.compute_min_distance(candidate.stop());
+      candidate.direction() = Interval::FROM_SOURCE;
+
+      update_list_and_queue(interval_list(e), &candidate, 1);
+    }
+  }
+}
+
+static int reps = 0;
+
+// propagation algorithm stops after reaching the certain distance from the
+// source
+void GeodesicAlgorithmExact::propagate(const std::vector<SurfacePoint>& sources, double max_propagation_distance,
+                                       const std::vector<SurfacePoint>& stop_points) {
+
+  set_stop_conditions(stop_points, max_propagation_distance);
+  set_sources(sources);
+  initialize_propagation_data();
+
+  clock_t start = clock();
+
+  unsigned satisfied_index = 0;
+
+  m_iterations = 0; // for statistics
+  m_queue_max_size = 0;
+
+  IntervalWithStop candidates[2];
+  geom.requireCornerAngles();
+
+  while (!m_queue.empty()) {
+    // if (++reps > 2) return;
+    // std::cout << m_queue.size() << std::endl;
+    m_queue_max_size = std::max(m_queue.size(), m_queue_max_size);
+
+    unsigned const check_period = 10;
+    if (++m_iterations % check_period == 0) // check if we covered all required vertices
+    {
+      if (check_stop_conditions(satisfied_index)) {
+        break;
+      }
+    }
+
+    interval_pointer min_interval = *m_queue.begin();
+    m_queue.erase(m_queue.begin());
+    Edge gc_edge = min_interval->edge();
+    Halfedge he = gc_edge.halfedge();
+    list_pointer list = interval_list(gc_edge);
+    // std::cout << "\tprocessing edge " << edge->id() << std::endl;
+    // std::cout << "\t\t with weight " << min_interval->min() << std::endl;
+
+    assert(min_interval->d() < GEODESIC_INF);
+
+    bool const first_interval = min_interval->start() == 0.0;
+    // bool const last_interval = min_interval->stop() == edge->length();
+    bool const last_interval = min_interval->next() == nullptr;
+
+    auto saddleOrBoundary = [&](Vertex v) -> bool {
+      geom.requireVertexGaussianCurvatures();
+      bool saddle = geom.vertexGaussianCurvatures[v] < 0;
+      geom.unrequireVertexGaussianCurvatures();
+      return saddle || v.isBoundary();
+    };
+
+    bool const turn_left = saddleOrBoundary(he.tailVertex());
+    bool const turn_right = saddleOrBoundary(he.tipVertex());
+
+    std::vector<Halfedge> adjacentHalfedges{he};
+    if (!gc_edge.isBoundary()) {
+      adjacentHalfedges.push_back(he.twin());
+    }
+
+    for (unsigned i = 0; i < adjacentHalfedges.size(); ++i) // two possible faces to propagate
+    {
+      if (!gc_edge.isBoundary()) // just in case, always propagate
+                                 // boundary edges
+      {
+        if ((i == 0 && min_interval->direction() == Interval::FROM_FACE_0) ||
+            (i == 1 && min_interval->direction() == Interval::FROM_FACE_1)) {
+          continue;
+        }
+      }
+
+      Halfedge gc_he = adjacentHalfedges[i];
+      Face gc_face = gc_he.face();
+
+      // if we come from 1, go to 2
+      Edge gc_next_edge = (gc_he == he) ? gc_he.next().next().edge() : gc_he.next().edge();
+      double next_edge_length = geom.edgeLengths[gc_next_edge];
+      double corner_angle =
+          (gc_he == he) ? geom.cornerAngles[gc_he.corner()] : geom.cornerAngles[gc_he.next().corner()];
+
+      unsigned num_propagated = compute_propagated_parameters(min_interval->pseudo_x(), min_interval->pseudo_y(),
+                                                              min_interval->d(), // parameters of the interval
+                                                              min_interval->start(),
+                                                              min_interval->stop(), // start/end of the interval
+                                                              corner_angle,         // corner angle
+                                                              next_edge_length,     // length of the new edge
+                                                              first_interval, // if it is the first interval on the edge
+                                                              last_interval, turn_left, turn_right,
+                                                              candidates); // if it is the last interval on the edge
+      bool propagate_to_right = true;
+
+      if (num_propagated) {
+        if (candidates[num_propagated - 1].stop() != next_edge_length) {
+          propagate_to_right = false;
+        }
+
+        // if the origins coinside, do not invert
+        // intervals
+        bool const invert = gc_next_edge.halfedge().tailVertex() != he.tailVertex();
+
+        construct_propagated_intervals(invert, // do not inverse
+                                       gc_next_edge, gc_face, candidates, num_propagated, min_interval);
+
+        update_list_and_queue(interval_list(gc_next_edge), candidates, num_propagated);
+      }
+
+      if (propagate_to_right) {
+        // propogation to the right edge
+        double length = geom.edgeLengths[gc_edge];
+
+        gc_next_edge = (gc_he == he) ? gc_he.next().edge() : gc_he.next().next().edge();
+
+        next_edge_length = geom.edgeLengths[gc_next_edge];
+        corner_angle = (gc_he == he) ? geom.cornerAngles[gc_he.next().corner()] : geom.cornerAngles[gc_he.corner()];
+
+        num_propagated = compute_propagated_parameters(length - min_interval->pseudo_x(), min_interval->pseudo_y(),
+                                                       min_interval->d(), // parameters of the interval
+                                                       length - min_interval->stop(),
+                                                       length - min_interval->start(), // start/end of the interval
+                                                       corner_angle,                   // corner angle
+                                                       next_edge_length,               // length of the new edge
+                                                       last_interval, // if it is the first interval on the edge
+                                                       first_interval, turn_right, turn_left,
+                                                       candidates); // if it is the last interval on the edge
+
+        if (num_propagated) {
+          // if the origins coinside, do not invert intervals
+          bool const invert = gc_next_edge.halfedge().tailVertex() != he.tipVertex();
+
+          construct_propagated_intervals(invert, // do not inverse
+                                         gc_next_edge, gc_face, candidates, num_propagated, min_interval);
+
+          update_list_and_queue(interval_list(gc_next_edge), candidates, num_propagated);
+        }
+      }
+    }
+  }
+
+  m_propagation_distance_stopped = m_queue.empty() ? GEODESIC_INF : (*m_queue.begin())->min();
+  clock_t stop = clock();
+  m_time_consumed = (static_cast<double>(stop) - static_cast<double>(start)) / CLOCKS_PER_SEC;
+
+  geom.unrequireCornerAngles();
+
+  /*	for(unsigned i=0; i<m_edge_interval_lists.size(); ++i)
+    {
+      list_pointer list = &m_edge_interval_lists[i];
+      interval_pointer p = list->first();
+      assert(p->start() == 0.0);
+      while(p->next())
+      {
+        assert(p->stop() == p->next()->start());
+        assert(p->d() < GEODESIC_INF);
+        p = p->next();
+      }
+    }*/
+}
+
+
+bool GeodesicAlgorithmExact::check_stop_conditions(unsigned& index) {
+  double queue_distance = (*m_queue.begin())->min();
+  double stop_dist = stop_distance();
+  if (stop_dist < GEODESIC_INF && queue_distance < stop_distance()) {
+    return false;
+  }
+
+  if (m_stop_vertices.empty()) {
+    return false;
+  }
+
+  while (index < m_stop_vertices.size()) {
+    Vertex v = m_stop_vertices[index].first;
+    Edge edge = v.halfedge().edge(); // take any edge
+
+    double distance = edge.halfedge().tailVertex() == v ? interval_list(edge)->signal(0.0)
+                                                        : interval_list(edge)->signal(geom.edgeLengths[edge]);
+
+    if (queue_distance < distance + m_stop_vertices[index].second) {
+      return false;
+    }
+
+    ++index;
+  }
+  return true;
+}
+
+
+void GeodesicAlgorithmExact::update_list_and_queue(list_pointer list,
+                                                   IntervalWithStop* candidates, // up to two candidates
+                                                   unsigned num_candidates) {
+  assert(num_candidates <= 2);
+  // assert(list->first() != nullptr);
+  Edge gc_edge = list->edge();
+  double edge_length = geom.edgeLengths[gc_edge];
+  double const local_epsilon = SMALLEST_INTERVAL_RATIO * edge_length;
+
+  if (list->first() == nullptr) {
+    interval_pointer* p = &list->first();
+    IntervalWithStop* first;
+    IntervalWithStop* second;
+
+    if (num_candidates == 1) {
+      first = candidates;
+      second = candidates;
+      first->compute_min_distance(first->stop());
+    } else {
+      if (candidates->start() <= (candidates + 1)->start()) {
+        first = candidates;
+        second = candidates + 1;
+      } else {
+        first = candidates + 1;
+        second = candidates;
+      }
+      assert(first->stop() == second->start());
+
+      first->compute_min_distance(first->stop());
+      second->compute_min_distance(second->stop());
+    }
+
+    if (first->start() > 0.0) {
+      *p = m_memory_allocator.allocate();
+      (*p)->initialize(geom, gc_edge, edge_length);
+      p = &(*p)->next();
+    }
+
+    *p = m_memory_allocator.allocate();
+    memcpy(*p, first, sizeof(Interval));
+    m_queue.insert(*p);
+
+    if (num_candidates == 2) {
+      p = &(*p)->next();
+      *p = m_memory_allocator.allocate();
+      memcpy(*p, second, sizeof(Interval));
+      m_queue.insert(*p);
+    }
+
+    if (second->stop() < edge_length) {
+      p = &(*p)->next();
+      *p = m_memory_allocator.allocate();
+      (*p)->initialize(geom, gc_edge, edge_length);
+      (*p)->start() = second->stop();
+    } else {
+      (*p)->next() = nullptr;
+    }
+    return;
+  }
+
+  bool propagate_flag;
+
+  for (unsigned i = 0; i < num_candidates; ++i) // for all new intervals
+  {
+    IntervalWithStop* q = &candidates[i];
+
+    interval_pointer previous = nullptr;
+
+    interval_pointer p = list->first();
+    assert(p->start() == 0.0);
+
+    while (p != nullptr && p->stop() - local_epsilon < q->start()) {
+      p = p->next();
+    }
+
+    while (p != nullptr && p->start() < q->stop() - local_epsilon) // go through all old intervals
+    {
+      unsigned const N = intersect_intervals(p, q); // interset two intervals
+
+      if (N == 1) {
+        if (map[0] == OLD) // if "p" is always better, we do not need to
+                           // update anything)
+        {
+          if (previous) // close previous interval and put in into the
+                        // queue
+          {
+            previous->next() = p;
+            previous->compute_min_distance(p->start());
+            m_queue.insert(previous);
+            previous = nullptr;
+          }
+
+          p = p->next();
+
+        } else if (previous) // extend previous interval to cover
+                             // everything; remove p
+        {
+          previous->next() = p->next();
+          erase_from_queue(p);
+          m_memory_allocator.deallocate(p);
+
+          p = previous->next();
+        } else // p becomes "previous"
+        {
+          previous = p;
+          interval_pointer next = p->next();
+          erase_from_queue(p);
+
+          memcpy(previous, q, sizeof(Interval));
+
+          previous->start() = start[0];
+          previous->next() = next;
+
+          p = next;
+        }
+        continue;
+      }
+
+      // update_flag = true;
+
+      Interval swap(*p); // used for swapping information
+      propagate_flag = erase_from_queue(p);
+
+      for (unsigned j = 1; j < N; ++j) // no memory is needed for the first one
+      {
+        i_new[j] = m_memory_allocator.allocate(); // create new
+                                                  // intervals
+      }
+
+      if (map[0] == OLD) // finish previous, if any
+      {
+        if (previous) {
+          previous->next() = p;
+          previous->compute_min_distance(previous->stop());
+          m_queue.insert(previous);
+          previous = nullptr;
+        }
+        i_new[0] = p;
+        p->next() = i_new[1];
+        p->start() = start[0];
+      } else if (previous) // extend previous interval to cover
+                           // everything; remove p
+      {
+        i_new[0] = previous;
+        previous->next() = i_new[1];
+        m_memory_allocator.deallocate(p);
+        previous = nullptr;
+      } else // p becomes "previous"
+      {
+        i_new[0] = p;
+        memcpy(p, q, sizeof(Interval));
+
+        p->next() = i_new[1];
+        p->start() = start[0];
+      }
+
+      assert(!previous);
+
+      for (unsigned j = 1; j < N; ++j) {
+        interval_pointer current_interval = i_new[j];
+
+        if (map[j] == OLD) {
+          memcpy(current_interval, &swap, sizeof(Interval));
+        } else {
+          memcpy(current_interval, q, sizeof(Interval));
+        }
+
+        if (j == N - 1) {
+          current_interval->next() = swap.next();
+        } else {
+          current_interval->next() = i_new[j + 1];
+        }
+
+        current_interval->start() = start[j];
+      }
+
+      for (unsigned j = 0; j < N; ++j) // find "min" and add the intervals to the queue
+      {
+        if (j == N - 1 && map[j] == NEW) {
+          previous = i_new[j];
+        } else {
+          interval_pointer current_interval = i_new[j];
+
+          current_interval->compute_min_distance(current_interval->stop()); // compute minimal distance
+
+          if (map[j] == NEW || (map[j] == OLD && propagate_flag)) {
+            m_queue.insert(current_interval);
+          }
+        }
+      }
+
+      p = swap.next();
+    }
+
+    if (previous) // close previous interval and put in into the queue
+    {
+      previous->compute_min_distance(previous->stop());
+      m_queue.insert(previous);
+      previous = nullptr;
+    }
+  }
+}
+
+unsigned GeodesicAlgorithmExact::compute_propagated_parameters(
+    double pseudo_x, double pseudo_y,
+    double d, // parameters of the interval
+    double begin,
+    double end,          // start/end of the interval
+    double alpha,        // corner angle
+    double L,            // length of the new edge
+    bool first_interval, // if it is the first interval on the edge
+    bool last_interval, bool turn_left, bool turn_right,
+    IntervalWithStop* candidates) // if it is the last interval on the edge
+{
+  assert(pseudo_y <= 0.0);
+  assert(d < GEODESIC_INF / 10.0);
+  assert(begin <= end);
+  assert(first_interval ? (begin == 0.0) : true);
+
+  IntervalWithStop* p = candidates;
+
+  if (std::abs(pseudo_y) <= 1e-30) // pseudo-source is on the edge
+  {
+    if (first_interval && pseudo_x <= 0.0) {
+      p->start() = 0.0;
+      p->stop() = L;
+      p->d() = d - pseudo_x;
+      p->pseudo_x() = 0.0;
+      p->pseudo_y() = 0.0;
+      return 1;
+    } else if (last_interval && pseudo_x >= end) {
+      p->start() = 0.0;
+      p->stop() = L;
+      p->d() = d + pseudo_x - end;
+      p->pseudo_x() = end * cos(alpha);
+      p->pseudo_y() = -end * sin(alpha);
+      return 1;
+    } else if (pseudo_x >= begin && pseudo_x <= end) {
+      p->start() = 0.0;
+      p->stop() = L;
+      p->d() = d;
+      p->pseudo_x() = pseudo_x * cos(alpha);
+      p->pseudo_y() = -pseudo_x * sin(alpha);
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  double sin_alpha = sin(alpha);
+  double cos_alpha = cos(alpha);
+
+  // important: for the first_interval, this function returns zero only if the
+  // new edge is "visible" from the source if the new edge can be covered only
+  // after turn_over, the value is negative (-1.0)
+  double L1 = compute_positive_intersection(begin, pseudo_x, pseudo_y, sin_alpha, cos_alpha);
+
+  if (L1 < 0 || L1 >= L) {
+    if (first_interval && turn_left) {
+      p->start() = 0.0;
+      p->stop() = L;
+      p->d() = d + sqrt(pseudo_x * pseudo_x + pseudo_y * pseudo_y);
+      p->pseudo_y() = 0.0;
+      p->pseudo_x() = 0.0;
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  double L2 = compute_positive_intersection(end, pseudo_x, pseudo_y, sin_alpha, cos_alpha);
+
+  if (L2 < 0 || L2 >= L) {
+    p->start() = L1;
+    p->stop() = L;
+    p->d() = d;
+    p->pseudo_x() = cos_alpha * pseudo_x + sin_alpha * pseudo_y;
+    p->pseudo_y() = -sin_alpha * pseudo_x + cos_alpha * pseudo_y;
+
+    return 1;
+  }
+
+  p->start() = L1;
+  p->stop() = L2;
+  p->d() = d;
+  p->pseudo_x() = cos_alpha * pseudo_x + sin_alpha * pseudo_y;
+  p->pseudo_y() = -sin_alpha * pseudo_x + cos_alpha * pseudo_y;
+  assert(p->pseudo_y() <= 0.0);
+
+  if (!(last_interval && turn_right)) {
+    return 1;
+  } else {
+    p = candidates + 1;
+
+    p->start() = L2;
+    p->stop() = L;
+    double dx = pseudo_x - end;
+    p->d() = d + sqrt(dx * dx + pseudo_y * pseudo_y);
+    p->pseudo_x() = end * cos_alpha;
+    p->pseudo_y() = -end * sin_alpha;
+
+    return 2;
+  }
+}
+
+void GeodesicAlgorithmExact::construct_propagated_intervals(bool invert, Edge gc_edge,
+                                                            Face gc_face, // constructs iNew from the rest of the data
+                                                            IntervalWithStop* candidates,
+                                                            unsigned& num_candidates, // up to two candidates
+                                                            interval_pointer source_interval) {
+
+  double edge_length = geom.edgeLengths[gc_edge];
+  double local_epsilon = SMALLEST_INTERVAL_RATIO * edge_length;
+
+  // kill very small intervals in order to avoid precision problems
+  if (num_candidates == 2) {
+    double start = std::min(candidates->start(), (candidates + 1)->start());
+    double stop = std::max(candidates->stop(), (candidates + 1)->stop());
+    if (candidates->stop() - candidates->start() < local_epsilon) // kill interval 0
+    {
+      *candidates = *(candidates + 1);
+      num_candidates = 1;
+      candidates->start() = start;
+      candidates->stop() = stop;
+    } else if ((candidates + 1)->stop() - (candidates + 1)->start() < local_epsilon) {
+      num_candidates = 1;
+      candidates->start() = start;
+      candidates->stop() = stop;
+    }
+  }
+
+  IntervalWithStop* first;
+  IntervalWithStop* second;
+  if (num_candidates == 1) {
+    first = candidates;
+    second = candidates;
+  } else {
+    if (candidates->start() <= (candidates + 1)->start()) {
+      first = candidates;
+      second = candidates + 1;
+    } else {
+      first = candidates + 1;
+      second = candidates;
+    }
+    assert(first->stop() == second->start());
+  }
+
+  if (first->start() < local_epsilon) {
+    first->start() = 0.0;
+  }
+  if (edge_length - second->stop() < local_epsilon) {
+    second->stop() = edge_length;
+  }
+
+
+  // invert intervals if necessary; fill missing data and set pointers
+  // correctly
+  Interval::DirectionType direction =
+      (gc_face == gc_edge.halfedge().face()) ? Interval::FROM_FACE_0 : Interval::FROM_FACE_1;
+
+  if (!invert) // in this case everything is straighforward, we do not have to
+               // invert the intervals
+  {
+    for (unsigned i = 0; i < num_candidates; ++i) {
+      IntervalWithStop* p = candidates + i;
+
+      p->next() = (i == num_candidates - 1) ? nullptr : candidates + i + 1;
+      p->edge() = gc_edge;
+      p->edge_length() = edge_length;
+      p->direction() = direction;
+      p->source_index() = source_interval->source_index();
+
+      p->min() = 0.0; // it will be changed later on
+
+      assert(p->start() < p->stop());
+    }
+  } else // now we have to invert the intervals
+  {
+    for (unsigned i = 0; i < num_candidates; ++i) {
+      IntervalWithStop* p = candidates + i;
+
+      p->next() = (i == 0) ? nullptr : candidates + i - 1;
+      p->edge() = gc_edge;
+      p->edge_length() = edge_length;
+      p->direction() = direction;
+      p->source_index() = source_interval->source_index();
+
+      double length = edge_length;
+      p->pseudo_x() = length - p->pseudo_x();
+
+      double start = length - p->stop();
+      p->stop() = length - p->start();
+      p->start() = start;
+
+      p->min() = 0;
+
+      assert(p->start() < p->stop());
+      assert(p->start() >= 0.0);
+      assert(p->stop() <= edge_length);
+    }
+  }
+}
+
+
+std::pair<unsigned, double> GeodesicAlgorithmExact::closestSource(const SurfacePoint& point) {
+
+  double best_interval_position;
+  unsigned best_source_index;
+  double best_source_distance;
+
+  best_first_interval(point, best_source_distance, best_interval_position, best_source_index);
+
+  return std::make_pair(best_source_index, best_source_distance);
+}
+
+double GeodesicAlgorithmExact::getDistance(const SurfacePoint& point) { return closestSource(point).second; }
+
+VertexData<double> GeodesicAlgorithmExact::getDistanceFunction() {
+  VertexData<double> distances(mesh);
+  for (Vertex v : mesh.vertices()) {
+    distances[v] = closestSource(SurfacePoint(v)).second;
+  }
+  return distances;
+}
+
+interval_pointer GeodesicAlgorithmExact::best_first_interval(const SurfacePoint& point, double& best_total_distance,
+                                                             double& best_interval_position,
+                                                             unsigned& best_source_index) {
+
+  interval_pointer best_interval = nullptr;
+  best_total_distance = GEODESIC_INF;
+
+  switch (point.type) {
+  case SurfacePointType::Vertex: {
+    Vertex v = point.vertex;
+    for (Edge e : v.adjacentEdges()) {
+      list_pointer list = interval_list(e);
+
+      // double position = e->v0()->id() == v->id() ? 0.0 : e->length();
+      double position = e.halfedge().tailVertex() == v ? 0.0 : geom.edgeLengths[e];
+
+      interval_pointer interval = list->covering_interval(position);
+      if (interval) {
+        double distance = interval->signal(position);
+
+        if (distance < best_total_distance) {
+          best_interval = interval;
+          best_total_distance = distance;
+          best_interval_position = position;
+          best_source_index = interval->source_index();
+        }
+      }
+    }
+    break;
+  }
+  case SurfacePointType::Edge: {
+    // TODO: untested branch
+    Edge e = point.edge;
+    list_pointer list = interval_list(e);
+
+    Vertex gcTail = e.halfedge().tailVertex();
+
+    best_interval_position = exactgeodesic::compute_surface_distance(geom, point, gcTail);
+    best_interval = list->covering_interval(best_interval_position);
+    if (best_interval) {
+      // assert(best_interval && best_interval->d() < GEODESIC_INF);
+      best_total_distance = best_interval->signal(best_interval_position);
+      best_source_index = best_interval->source_index();
+    }
+    break;
+  }
+  case SurfacePointType::Face: {
+    Face f = point.face;
+    for (Edge e : f.adjacentEdges()) {
+      list_pointer list = interval_list(e);
+
+      double offset;
+      double distance;
+      interval_pointer interval;
+
+      list->find_closest_point(geom, point, offset, distance, interval);
+
+      if (interval && distance < best_total_distance) {
+        best_interval = interval;
+        best_total_distance = distance;
+        best_interval_position = offset;
+        best_source_index = interval->source_index();
+      }
+    }
+
+    // check for all sources that might be located inside this face
+    SortedSources::sorted_iterator_pair local_sources = m_sources.sources(point);
+    for (SortedSources::sorted_iterator it = local_sources.first; it != local_sources.second; ++it) {
+      SurfacePointWithIndex* source = *it;
+      double distance = exactgeodesic::compute_surface_distance(geom, point, *source);
+      if (distance < best_total_distance) {
+        best_interval = nullptr;
+        best_total_distance = distance;
+        best_interval_position = 0.0;
+        best_source_index = source->index();
+      }
+    }
+    break;
+  }
+  }
+
+  if (best_total_distance > m_propagation_distance_stopped) // result is unreliable
+  {
+    best_total_distance = GEODESIC_INF;
+    return nullptr;
+  } else {
+    return best_interval;
+  }
+}
+
+// trace back piecewise-linear path
+std::vector<SurfacePoint> GeodesicAlgorithmExact::traceBack(const SurfacePoint& destination) {
+  std::vector<SurfacePoint> path;
+
+  double best_total_distance;
+  double best_interval_position;
+  unsigned source_index = std::numeric_limits<unsigned>::max();
+  interval_pointer best_interval =
+      best_first_interval(destination, best_total_distance, best_interval_position, source_index);
+
+  // unable to find the right path
+  if (best_total_distance >= GEODESIC_INF / 2.0) {
+    return {};
+  }
+
+  path.push_back(destination);
+
+  if (best_interval) // if we did not hit the face source immediately
+  {
+    std::vector<Edge> possible_edges;
+    possible_edges.reserve(10);
+
+    // while this point is not in the direct visibility of some
+    // source (if we are inside the FACE, we obviously hit the source)
+    while (visible_from_source(path.back()) < 0) {
+      SurfacePoint& q = path.back();
+
+      possible_traceback_edges(q, possible_edges);
+
+      interval_pointer interval;
+      double total_distance;
+      double position;
+
+      // bool verbose = (q.gcPoint.edge == mesh.edge(24655) ||
+      //                 q.gcPoint.edge == mesh.edge(24656));
+      // bool verbose = 2 < path.size() && path.size() < 5;
+      bool verbose = false;
+      best_point_on_the_edge_set(q, possible_edges, interval, total_distance, position);
+      // std::cout << total_distance + length(path) << std::endl;
+      assert(total_distance < GEODESIC_INF);
+      source_index = interval->source_index();
+
+
+      Edge gc_edge = interval->edge();
+      Halfedge gc_he = gc_edge.halfedge();
+      double edge_length = geom.edgeLengths[gc_edge];
+
+      double local_epsilon = SMALLEST_INTERVAL_RATIO * edge_length;
+      if (position < local_epsilon) {
+        Vertex v = gc_he.tailVertex();
+        path.push_back(SurfacePoint(v));
+      } else if (position > edge_length - local_epsilon) {
+        Vertex v = gc_he.tipVertex();
+        path.push_back(SurfacePoint(v));
+      } else {
+        double normalized_position = position / edge_length;
+        path.push_back(SurfacePoint(gc_edge, normalized_position));
+      }
+    }
+  }
+
+  SurfacePoint& source = static_cast<SurfacePoint&>(m_sources[source_index]);
+  if (exactgeodesic::compute_surface_distance(geom, path.back(), source) > 0) {
+    path.push_back(source);
+  }
+
+  return path;
+}
+
+void GeodesicAlgorithmExact::print_statistics() {
+  std::cout << "propagation step took " << m_time_consumed << " seconds " << std::endl;
+
+  unsigned interval_counter = 0;
+  for (unsigned i = 0; i < m_edge_interval_lists.size(); ++i) {
+    interval_counter += m_edge_interval_lists[i].number_of_intervals();
+  }
+  double intervals_per_edge = (double)interval_counter / (double)m_edge_interval_lists.size();
+
+  double memory = m_edge_interval_lists.size() * sizeof(IntervalList) + interval_counter * sizeof(Interval);
+
+  std::cout << "uses about " << memory / 1e6 << "Mb of memory" << std::endl;
+  std::cout << interval_counter << " total intervals, or " << intervals_per_edge << " intervals per edge" << std::endl;
+  std::cout << "maximum interval queue size is " << m_queue_max_size << std::endl;
+  std::cout << "number of interval propagations is " << m_iterations << std::endl;
+}
+
+IntervalList GeodesicAlgorithmExact::getEdgeIntervals(Edge e) const { return m_edge_interval_lists[e]; }
+
+void GeodesicAlgorithmExact::set_stop_conditions(const std::vector<SurfacePoint>& stop_points, double stop_distance) {
+  m_max_propagation_distance = stop_distance;
+
+  if (stop_points.empty()) {
+    m_stop_vertices.clear();
+    return;
+  }
+
+  m_stop_vertices.reserve(stop_points.size());
+
+  // TODO: not tested
+  std::vector<Vertex> possible_vertices;
+  for (const SurfacePoint& point : stop_points) {
+    possible_vertices.clear();
+    exactgeodesic::compute_closest_vertices(point, &possible_vertices);
+
+    Vertex closest_vertex;
+    double min_distance = 1e100;
+    for (Vertex v : possible_vertices) {
+      double distance = exactgeodesic::compute_surface_distance(geom, point, SurfacePoint(v));
+      if (distance < min_distance) {
+        min_distance = distance;
+        closest_vertex = v;
+      }
+    }
+    assert(closest_vertex != Vertex());
+
+    m_stop_vertices.push_back(std::make_pair(closest_vertex, min_distance));
+  }
+}
+
+void GeodesicAlgorithmExact::clear() {
+  m_memory_allocator.clear();
+  m_queue.clear();
+  for (unsigned i = 0; i < m_edge_interval_lists.size(); ++i) {
+    m_edge_interval_lists[i].clear();
+  }
+  m_propagation_distance_stopped = GEODESIC_INF;
+};
+
+} // namespace surface
+} // namespace geometrycentral

--- a/src/surface/exact_geodesics.cpp
+++ b/src/surface/exact_geodesics.cpp
@@ -632,13 +632,15 @@ void GeodesicAlgorithmExact::update_list_and_queue(list_pointer list,
     }
 
     *p = m_memory_allocator.allocate();
-    memcpy(*p, first, sizeof(Interval));
+    // memcpy(*p, first, sizeof(Interval));
+    **p = *first;
     m_queue.insert(*p);
 
     if (num_candidates == 2) {
       p = &(*p)->next();
       *p = m_memory_allocator.allocate();
-      memcpy(*p, second, sizeof(Interval));
+      // memcpy(*p, second, sizeof(Interval));
+      **p = *second;
       m_queue.insert(*p);
     }
 
@@ -701,7 +703,8 @@ void GeodesicAlgorithmExact::update_list_and_queue(list_pointer list,
           interval_pointer next = p->next();
           erase_from_queue(p);
 
-          memcpy(previous, q, sizeof(Interval));
+          // memcpy(previous, q, sizeof(Interval));
+          *previous = *q;
 
           previous->start() = start[0];
           previous->next() = next;
@@ -743,7 +746,8 @@ void GeodesicAlgorithmExact::update_list_and_queue(list_pointer list,
       } else // p becomes "previous"
       {
         i_new[0] = p;
-        memcpy(p, q, sizeof(Interval));
+        // memcpy(p, q, sizeof(Interval));
+        *p = *q;
 
         p->next() = i_new[1];
         p->start() = start[0];
@@ -755,9 +759,11 @@ void GeodesicAlgorithmExact::update_list_and_queue(list_pointer list,
         interval_pointer current_interval = i_new[j];
 
         if (map[j] == OLD) {
-          memcpy(current_interval, &swap, sizeof(Interval));
+          // memcpy(current_interval, &swap, sizeof(Interval));
+          *current_interval = swap;
         } else {
-          memcpy(current_interval, q, sizeof(Interval));
+          // memcpy(current_interval, q, sizeof(Interval));
+          *current_interval = *q;
         }
 
         if (j == N - 1) {


### PR DESCRIPTION
I ported Kirsanov's implementation of MMP to run in geometry central on intrinsic triangulations. Now it uses geometry central's mesh data structures and does its computations based on edge lengths rather than vertex positions, but all of the algorithm logic (and most of the code) is left exactly the same.

After doing this, I noticed that there is a bunch of commented-out code in `exact_polyhedral_geodesics.h` 😄. What's the status of that stuff? If there are plans for getting it working soon, I'd be happy to make any changes to this code to give a more consistent interface or otherwise delineate the differences more clearly.

Also, I'm not totally sure how licensing is supposed to work here. Kirsanov's code is MIT licensed, so based on a cursory google search it seems like it's legal to include a bunch of the code verbatim. I left his copyright headers at the top of the files along with an added link to the original code. Hopefully that suffices