### PR TITLE
Improvements to integer coordinate edge splits

### DIFF
--- a/include/geometrycentral/surface/integer_coordinates_intrinsic_triangulation.h
+++ b/include/geometrycentral/surface/integer_coordinates_intrinsic_triangulation.h
@@ -48,6 +48,8 @@ public:
   EdgeData<std::vector<SurfacePoint>> traceAllInputEdgesAlongIntrinsic() override;
   std::vector<SurfacePoint> traceInputHalfedgeAlongIntrinsic(Halfedge inputHe) override;
 
+  bool checkEdgeOriginal(Edge e) const override;
+
   // ======================================================
   // ======== Low-Level Mutators
   // ======================================================
@@ -64,7 +66,8 @@ public:
 
   Halfedge splitEdge(Halfedge he, double tSplit) override;
 
-  // Check if an edge can be flipped geometrically, as defined by the (relative) signed areas of the resulting triangles; positive values mean flippable.
+  // Check if an edge can be flipped geometrically, as defined by the (relative) signed areas of the resulting
+  // triangles; positive values mean flippable.
   double checkFlip(Edge e);
 
   // Insert circumcenter or split segment
@@ -72,8 +75,8 @@ public:
 
   Vertex splitFace(Face f, Vector3 bary, bool verbose = false);
   Vertex splitEdge(Edge e, double bary, bool verbose = false);
-  Vertex splitInteriorEdge(Edge e, double bary, bool verbose = false);
-  Vertex splitBoundaryEdge(Edge e, double bary, bool verbose = false);
+  Halfedge splitInteriorEdge(Halfedge he, double bary, bool verbose = false);
+  Halfedge splitBoundaryEdge(Halfedge he, double bary, bool verbose = false);
 
   // Move a vertex `v` in direction `vec`, represented as a vector in the
   // vertex's tangent space.
@@ -99,6 +102,10 @@ public:
   // and computes the corresponding point on the input mesh, as well as the normal coordinates of
   // the edges connecting this new point to f's vertices.
   std::pair<SurfacePoint, std::array<int, 3>> computeFaceSplitData(Face f, Vector3 bary, bool verbose = false);
+
+  // Computes the corresponding point on the input mesh, as well as which segment the point belongs to.
+  // The segment is specified by an integer 0 <= segmentIndex <= normalCoordinates[he.edge()]
+  std::pair<SurfacePoint, size_t> computeEdgeSplitData(Halfedge he, double tBary);
 
   // Compute the number of vertices in the common subdivision
   // i.e. intrinsicMesh->nVertices() plus the sum of the normal coordinates
@@ -134,10 +141,6 @@ private:
   // Construct the common subdivision for the current triangulation.
   void constructCommonSubdivision() override;
 };
-
-// Compute the cotan weight of halfedge ij in terms of the lengths of its
-// neighbors
-double halfedgeCotanWeight(double lij, double ljk, double lki);
 
 FaceData<Vector2> interpolateTangentVectorsB(const IntegerCoordinatesIntrinsicTriangulation& tri,
                                              const CommonSubdivision& cs, const FaceData<Vector2>& dataB);

--- a/include/geometrycentral/surface/intrinsic_triangulation.h
+++ b/include/geometrycentral/surface/intrinsic_triangulation.h
@@ -66,6 +66,7 @@ public:
   // this possiblity.
   EdgeData<bool> markedEdges;
   void setMarkedEdges(const EdgeData<bool>& markedEdges);
+  void clearMarkedEdges();
   // Is this a marked or boundary edge?
   bool isFixed(Edge e) const;
   bool isOnFixedEdge(Vertex v) const; // boundary vertex or on fixed edge
@@ -128,6 +129,12 @@ public:
   // face Otherwise return Face()
   Face getParentFace(Face f) const;
 
+  // Check if edge is shared with input mesh
+  virtual bool checkEdgeOriginal(Edge e) const = 0;
+
+  // Immediate computation of corner angle
+  double getCornerAngle(Corner c) const;
+
   // ======================================================
   // ======== High-Level Mutators
   // ======================================================
@@ -184,6 +191,13 @@ public:
 
   // Split an edge
   virtual Halfedge splitEdge(Halfedge he, double tSplit) = 0;
+
+
+  // ==== Misc
+  // Recover t-values after tracing
+  // Note that really we ought to just report these back from the tracing routine itself, which computes them
+  // internally. We don't have a nice API for passing that data around, so this lazily recovers it
+  std::vector<double> recoverTraceTValues(const std::vector<SurfacePoint>& edgeTrace);
 
   // ======================================================
   // ======== Callbacks

--- a/include/geometrycentral/surface/normal_coordinates.h
+++ b/include/geometrycentral/surface/normal_coordinates.h
@@ -49,7 +49,7 @@ public:
 
   // Count of edges emanating from each corner (nonnegative)
   VertexData<int> roundaboutDegrees;
-  
+
   // === Initialization
   void setCurvesFromEdges(ManifoldSurfaceMesh& mesh);
 
@@ -80,6 +80,9 @@ public:
 
   std::array<int, 3> computeBoundaryEdgeSplitDataGeodesic(IntrinsicGeometryInterface& geo, Edge e, double location);
 
+  // Compute the new normal coordinates after splitting edge e
+  // Edge e is split at segment iSeg, where 0 <= iSeg <= edgeCoords[e]
+  std::array<int, 4> computeInteriorEdgeSplitDataCombinatorial(IntrinsicGeometryInterface& geo, Edge e, size_t iSeg);
 
   // Check that these are valid normal coordinates, throw if not
   void validate() const;
@@ -200,7 +203,8 @@ std::vector<SurfacePoint> generateSingleGeodesicGeometry(ManifoldSurfaceMesh& me
 // Barycentric coordinates are 0 at the src of and edge and 1 at the dst
 std::vector<std::pair<SurfacePoint, double>> generateFullSingleGeodesicGeometry(ManifoldSurfaceMesh& mesh,
                                                                                 IntrinsicGeometryInterface& geo,
-                                                                                const NormalCoordinatesCurve& curve);
+                                                                                const NormalCoordinatesCurve& curve,
+                                                                                bool verbose = false);
 
 // Compute the new normal coordinates for an inserted vertex v in face f given
 // that v's barycentric coordinates and the barycentric coordinates of the

--- a/include/geometrycentral/surface/signpost_intrinsic_triangulation.h
+++ b/include/geometrycentral/surface/signpost_intrinsic_triangulation.h
@@ -77,7 +77,6 @@ public:
   // Split an edge
   Halfedge splitEdge(Halfedge he, double tSplit) override;
 
-
 protected:
 private:
   // ======================================================

--- a/include/geometrycentral/surface/signpost_intrinsic_triangulation.h
+++ b/include/geometrycentral/surface/signpost_intrinsic_triangulation.h
@@ -49,6 +49,8 @@ public:
   std::vector<SurfacePoint> traceInputHalfedgeAlongIntrinsic(Halfedge inputHe) override;
   std::vector<SurfacePoint> traceInputHalfedgeAlongIntrinsic(Halfedge inputHe, bool trimEnd);
 
+  bool checkEdgeOriginal(Edge e) const override;
+
   // ======================================================
   // ======== Low-Level Mutators
   // ======================================================
@@ -74,6 +76,7 @@ public:
 
   // Split an edge
   Halfedge splitEdge(Halfedge he, double tSplit) override;
+
 
 protected:
 private:
@@ -108,10 +111,6 @@ private:
 
   // Scale factor to take Euclidean data to cone data
   double vertexAngleScaling(Vertex v) const;
-
-  // Recover t-values after tracing
-  // Note that really we ought to just report these back from the tracing routine itself, which computes them internally. We don't have a nice API for passing that data around, so this lazily recovers it
-  std::vector<double> recoverTraceTValues(const std::vector<SurfacePoint>& edgeTrace);
 
   // Construct the common subdivision for the current triangulation.
   // WARNING: this signpost implementation does not properly populate some fields

--- a/include/geometrycentral/surface/surface_point.h
+++ b/include/geometrycentral/surface/surface_point.h
@@ -19,11 +19,11 @@ enum class SurfacePointType { Vertex = 0, Edge, Face };
 struct SurfacePoint {
 
   // === Constructors
-  SurfacePoint();                           // default: yields invalid SurfacePoint with Type::Vertex and null vertex
-  SurfacePoint(Vertex v);                   // at vertex
-  SurfacePoint(Edge e, double tEdge);       // in edge
+  SurfacePoint();                              // default: yields invalid SurfacePoint with Type::Vertex and null vertex
+  SurfacePoint(Vertex v);                      // at vertex
+  SurfacePoint(Edge e, double tEdge);          // in edge
   SurfacePoint(Halfedge he, double tHalfedge); // in edge (flips direction if needed)
-  SurfacePoint(Face f, Vector3 faceCoords); // in face
+  SurfacePoint(Face f, Vector3 faceCoords);    // in face
 
 
   // === Identifying data
@@ -51,6 +51,10 @@ struct SurfacePoint {
   // Returns the surface point as a face point in face f (see comment in inSomeFace()). If the the SurfacePoint is not
   // on or adjacent to the requested face, throws an error.
   inline SurfacePoint inFace(Face f) const;
+
+  // Returns the surface point as an edge point in edge e. If the the SurfacePoint is not on the edge or one of its
+  // adjacent vertices, throws an error
+  inline SurfacePoint inEdge(Edge e) const;
 
   // Return the nearest vertex to this surface point
   inline Vertex nearestVertex() const;
@@ -92,4 +96,3 @@ std::string to_string(geometrycentral::surface::SurfacePoint p);
 }
 
 #include "geometrycentral/surface/surface_point.ipp"
-

--- a/include/geometrycentral/surface/surface_point.ipp
+++ b/include/geometrycentral/surface/surface_point.ipp
@@ -147,6 +147,27 @@ inline SurfacePoint SurfacePoint::inFace(Face targetFace) const {
   return *this;
 }
 
+inline SurfacePoint SurfacePoint::inEdge(Edge targetEdge) const {
+  switch (type) {
+  case SurfacePointType::Vertex:
+    if (vertex == targetEdge.halfedge().tailVertex()) {
+      return SurfacePoint(targetEdge, 0);
+    } else if (vertex == targetEdge.halfedge().tipVertex()) {
+      return SurfacePoint(targetEdge, 1);
+    }
+    break;
+  case SurfacePointType::Edge:
+    if (edge == targetEdge) {
+      return *this;
+    }
+    break;
+  default:
+    break;
+  }
+  throw std::logic_error("SurfacePoint " + std::to_string(*this) + " not adjacent to target edge " +
+                         std::to_string(targetEdge));
+  return *this;
+}
 
 inline Vertex SurfacePoint::nearestVertex() const {
 
@@ -292,4 +313,3 @@ inline std::string to_string(geometrycentral::surface::SurfacePoint p) {
   return output.str();
 }
 } // namespace std
-

--- a/src/surface/integer_coordinates_intrinsic_triangulation.cpp
+++ b/src/surface/integer_coordinates_intrinsic_triangulation.cpp
@@ -677,19 +677,7 @@ IntegerCoordinatesIntrinsicTriangulation::computeFaceSplitData(Face f, Vector3 b
     std::array<Vector3, 3> vertexBary;
     size_t iV = 0;
     for (Vertex v : f.adjacentVertices()) {
-      if (insertionFace == Face()) {
-        std::cout << "Error: could not find parent face for " << f << std::endl;
-        std::cout << "Normal coordinates: " << std::endl;
-        for (Edge e : f.adjacentEdges()) {
-          std::cout << "\t" << e << "\t|\t" << normalCoordinates[e] << std::endl;
-        }
-      }
-      try {
-        vertexBary[iV] = vertexLocations[v].inFace(insertionFace).faceCoords;
-      } catch (std::exception& e) {
-        std::cout << "Error: " << vertexLocations[v] << " not adjacent to " << insertionFace << "?!" << std::endl;
-        throw e;
-      }
+      vertexBary[iV] = vertexLocations[v].inFace(insertionFace).faceCoords;
       iV++;
     }
 

--- a/src/surface/integer_coordinates_intrinsic_triangulation.cpp
+++ b/src/surface/integer_coordinates_intrinsic_triangulation.cpp
@@ -36,7 +36,7 @@ IntegerCoordinatesIntrinsicTriangulation::IntegerCoordinatesIntrinsicTriangulati
   normalCoordinates.setCurvesFromEdges(*intrinsicMesh);
 
   // TODO document/expose this somehow, rather than just doing it silently
-  if(mollifyEPS > 0) {
+  if (mollifyEPS > 0) {
     mollifyIntrinsic(*intrinsicMesh, edgeLengths, mollifyEPS);
   }
 
@@ -165,7 +165,7 @@ std::vector<SurfacePoint> IntegerCoordinatesIntrinsicTriangulation::traceInputHa
 
 SurfacePoint IntegerCoordinatesIntrinsicTriangulation::equivalentPointOnIntrinsic(const SurfacePoint& pointOnInput) {
   // TODO
-  throw std::runtime_error("not implemented");
+  throw std::runtime_error("equivalentPointOnIntrinsic not implemented");
   return SurfacePoint(Vertex());
 }
 
@@ -174,8 +174,7 @@ SurfacePoint IntegerCoordinatesIntrinsicTriangulation::equivalentPointOnInput(co
   case SurfacePointType::Vertex:
     return vertexLocations[pointOnIntrinsic.vertex];
   case SurfacePointType::Edge: {
-    SurfacePoint facePoint = pointOnIntrinsic.inSomeFace();
-    return computeFaceSplitData(facePoint.face, facePoint.faceCoords).first;
+    return computeEdgeSplitData(pointOnIntrinsic.edge.halfedge(), pointOnIntrinsic.tEdge).first;
   }
   case SurfacePointType::Face:
     return computeFaceSplitData(pointOnIntrinsic.face, pointOnIntrinsic.faceCoords).first;
@@ -183,6 +182,7 @@ SurfacePoint IntegerCoordinatesIntrinsicTriangulation::equivalentPointOnInput(co
   return SurfacePoint(); // unreachable
 }
 
+bool IntegerCoordinatesIntrinsicTriangulation::checkEdgeOriginal(Edge e) const { return normalCoordinates[e] == -1; }
 
 void IntegerCoordinatesIntrinsicTriangulation::constructCommonSubdivision() {
 
@@ -507,7 +507,6 @@ bool IntegerCoordinatesIntrinsicTriangulation::flipEdgeIfPossible(Edge e) {
 }
 
 
-
 double IntegerCoordinatesIntrinsicTriangulation::checkFlip(Edge e) {
   // Can't flip
   if (isFixed(e)) return std::numeric_limits<double>::infinity();
@@ -673,136 +672,24 @@ IntegerCoordinatesIntrinsicTriangulation::computeFaceSplitData(Face f, Vector3 b
   } else if (normalCoordinates[f.halfedge().edge()] <= 0 && normalCoordinates[f.halfedge().next().edge()] <= 0 &&
              normalCoordinates[f.halfedge().next().next().edge()] <= 0) {
 
-    // TODO: use getParentFace
-    insertionFace = Face();
-    // First, look for a FacePoint - that's the easiest thing to deal with
-    for (Vertex v : f.adjacentVertices()) {
-      if (vertexLocations[v].type == SurfacePointType::Face) {
-        if (insertionFace != Face()) {
-          // all faces should agree
-          GC_SAFETY_ASSERT(insertionFace == vertexLocations[v].face, "if there are no crossings, this face must "
-                                                                     "be contained inside a single input face");
-        } else {
-          insertionFace = vertexLocations[v].face;
-        }
-      }
-    }
-
-    if (insertionFace == Face()) {
-      // If we couldn't find a FacePoint, look for an EdgePoint
-      // Note that not all vertices can be shared - if they are, then we
-      // can't have any boundary crossings. But this happens sometimes
-      // anyway, and is handled next
-
-      auto containsVertex = [](Face f, Vertex v) -> bool {
-        for (Vertex vF : f.adjacentVertices()) {
-          if (vF == v) return true;
-        }
-        return false;
-      };
-
-      auto containsEdge = [](Face f, Edge e) -> bool {
-        for (Edge eF : f.adjacentEdges()) {
-          if (eF == e) return true;
-        }
-        return false;
-      };
-
-      auto compatible = [&](const SurfacePoint& pt, Face f) -> bool {
-        switch (pt.type) {
-        case SurfacePointType::Vertex:
-          return containsVertex(f, pt.vertex);
-        case SurfacePointType::Edge:
-          return containsEdge(f, pt.edge);
-        case SurfacePointType::Face:
-          return pt.face == f;
-        }
-        return false; // unreachable
-      };
-
-      for (Vertex v : f.adjacentVertices()) {
-        if (vertexLocations[v].type == SurfacePointType::Edge) {
-          Edge e = vertexLocations[v].edge;
-          Face f1 = e.halfedge().face();
-          Face f2 = e.halfedge().twin().face();
-
-          bool f1Okay = e.halfedge().isInterior();
-          bool f2Okay = e.halfedge().twin().isInterior();
-
-          for (Vertex w : f.adjacentVertices()) {
-            f1Okay = f1Okay && compatible(vertexLocations[w], f1);
-            f2Okay = f2Okay && compatible(vertexLocations[w], f2);
-          }
-
-          if ((f1 != f2) && (f1Okay && f2Okay)) {
-            std::cerr << "splitFace err: There are two options for an "
-                         "input "
-                         "face to insert "
-                         "in, and they both look fine. What should I "
-                         "do?. (In the meantime, I'm picking option 1)"
-                      << std::endl;
-          }
-
-          if (f1Okay) {
-            insertionFace = f1;
-          } else if (f2Okay) {
-            insertionFace = f2;
-          } else {
-            std::cout << " ==== Failed to find valid face to insert" << std::endl;
-            std::cout << "f1: " << f1 << " (isBoundaryLoop: " << f1.isBoundaryLoop() << ")" << std::endl;
-            std::cout << "f2: " << f2 << " (isBoundaryLoop: " << f2.isBoundaryLoop() << ")" << std::endl;
-            std::cout << "Underlying edge: " << e << " (isBoundary: " << e.isBoundary() << ")" << std::endl;
-
-            throw std::runtime_error("Could not find a valid face in inputMesh to "
-                                     "insert the new vertex into");
-          }
-        }
-      }
-    }
-
-    if (insertionFace == Face()) {
-      // In really degenerate situations, we can have triangles between
-      // three
-      bool allSharedVertices = true;
-      for (Vertex v : f.adjacentVertices()) {
-        allSharedVertices = allSharedVertices && vertexLocations[v].type == SurfacePointType::Vertex;
-      }
-      if (allSharedVertices) {
-        // Hope that we find a shared edge. If not, something terrible
-        // has happened
-        std::cout << vertexLocations[intrinsicMesh->vertex(2336)] << std::endl;
-        for (Halfedge he : f.adjacentHalfedges()) {
-          std::cout << std::endl;
-        }
-
-        for (Halfedge he : f.adjacentHalfedges()) {
-          if (normalCoordinates[he.edge()] < 0) {
-            Halfedge inputHalfedge = identifyInputEdge(he);
-            insertionFace = inputHalfedge.face();
-            insertionBary = bary;
-
-            if (inputHalfedge == insertionFace.halfedge()) {
-              // good!
-            } else if (inputHalfedge == insertionFace.halfedge().next()) {
-              insertionBary = rotate(rotate(insertionBary));
-            } else if (inputHalfedge == insertionFace.halfedge().next().next()) {
-              insertionBary = rotate(insertionBary);
-            } else {
-              throw std::runtime_error("Face " + std::to_string(insertionFace) + " is not triangular");
-            }
-            counts = {0, 0, 0};
-            break;
-          }
-        }
-      }
-    }
-
-    GC_SAFETY_ASSERT(insertionFace != Face(), "failed to find FacePoint.");
+    insertionFace = getParentFace(f);
 
     std::array<Vector3, 3> vertexBary;
     size_t iV = 0;
     for (Vertex v : f.adjacentVertices()) {
-      vertexBary[iV] = vertexLocations[v].inFace(insertionFace).faceCoords;
+      if (insertionFace == Face()) {
+        std::cout << "Error: could not find parent face for " << f << std::endl;
+        std::cout << "Normal coordinates: " << std::endl;
+        for (Edge e : f.adjacentEdges()) {
+          std::cout << "\t" << e << "\t|\t" << normalCoordinates[e] << std::endl;
+        }
+      }
+      try {
+        vertexBary[iV] = vertexLocations[v].inFace(insertionFace).faceCoords;
+      } catch (std::exception& e) {
+        std::cout << "Error: " << vertexLocations[v] << " not adjacent to " << insertionFace << "?!" << std::endl;
+        throw e;
+      }
       iV++;
     }
 
@@ -823,7 +710,7 @@ IntegerCoordinatesIntrinsicTriangulation::computeFaceSplitData(Face f, Vector3 b
     std::array<std::vector<std::vector<std::pair<SurfacePoint, double>>>, 3> geodesics;
     std::array<std::vector<double>, 3> transverseCrossingTimes;
     std::array<std::vector<double>, 3> boundaryCrossings;
-    std::array<std::vector<size_t>, 3> crossingID;
+    std::array<std::vector<size_t>, 3> crossingID; // Where along the curve is the crossing with our halfedge he?
     for (Halfedge he : f.adjacentHalfedges()) {
       for (int ind = 0; ind < normalCoordinates[he.edge()]; ind++) {
 
@@ -1164,6 +1051,123 @@ IntegerCoordinatesIntrinsicTriangulation::computeFaceSplitData(Face f, Vector3 b
   return {SurfacePoint(insertionFace, insertionBary), counts};
 }
 
+std::pair<SurfacePoint, size_t> IntegerCoordinatesIntrinsicTriangulation::computeEdgeSplitData(Halfedge he,
+                                                                                               double tBary) {
+
+  if (normalCoordinates[he.edge()] > 0) {
+    // If there are crossings along this edge, we have to determine where they are
+
+    // Find information about crossings along he. Logic copied in computeFaceSplitData
+    std::vector<NormalCoordinatesCurve> curves;
+    std::vector<std::vector<std::pair<SurfacePoint, double>>> geodesics;
+    std::vector<double> transverseCrossingTimes;
+    std::vector<double> heCrossingTimes;
+    std::vector<size_t> crossingID; // Where along the curve is the crossing with our halfedge he?
+    for (int ind = 0; ind < normalCoordinates[he.edge()]; ind++) {
+      // Get the topological crossings for the curve
+      NormalCoordinatesCurve crossings;
+      int centerCrossInd;
+      std::tie(crossings, centerCrossInd) = normalCoordinates.topologicalTraceBidirectional(he, ind);
+
+      curves.push_back(crossings);
+      geodesics.push_back(generateFullSingleGeodesicGeometry(*intrinsicMesh, *this, crossings));
+      std::vector<std::pair<SurfacePoint, double>>& geodesic = geodesics.back();
+      SurfacePoint& thisCross = geodesic[centerCrossInd + 1].first;
+      double tCross = (he.edge().halfedge() == he) ? thisCross.tEdge : 1 - thisCross.tEdge;
+      heCrossingTimes.push_back(tCross);
+      transverseCrossingTimes.push_back(geodesic[centerCrossInd + 1].second);
+      crossingID.push_back(centerCrossInd + 1);
+
+      // Halfedge inputHedge = identifyInputEdge(curves.back());
+      // std::cout << "\t\t\t crossing [input]: " << SurfacePoint(inputHedge, transverseCrossingTimes.back())
+      //           << "\t[intrinsic]: " << thisCross << std::endl;
+      // std::cout << "\t\t\t\t (from curve): ";
+      // for (const auto combinatorialPoint : curves.back().crossings)
+      //   std::cout << "(" << combinatorialPoint.first << ", " << combinatorialPoint.second << "), ";
+      // std::cout << std::endl;
+      // generateFullSingleGeodesicGeometry(*intrinsicMesh, *this, crossings, true);
+    }
+
+    int crossingSegment = normalCoordinates[he.edge()];
+    for (int iSeg = 0; iSeg < normalCoordinates[he.edge()]; iSeg++) {
+      if (heCrossingTimes[iSeg] > tBary) {
+        crossingSegment = iSeg;
+        break;
+      }
+    }
+
+    SurfacePoint segmentTail, segmentTip;
+    double tSegmentTail, tSegmentTip;
+    if (crossingSegment == 0) {
+      segmentTail = vertexLocations[he.tailVertex()];
+      tSegmentTail = 0;
+    } else {
+      Halfedge tailHedge = identifyInputEdge(curves[crossingSegment - 1]);
+      segmentTail = SurfacePoint(tailHedge, transverseCrossingTimes[crossingSegment - 1]);
+      tSegmentTail = heCrossingTimes[crossingSegment - 1];
+    }
+
+    if (crossingSegment == normalCoordinates[he.edge()]) {
+      segmentTip = vertexLocations[he.tipVertex()];
+      tSegmentTip = 1;
+    } else {
+      Halfedge tipHedge = identifyInputEdge(curves[crossingSegment]);
+      segmentTip = SurfacePoint(tipHedge, transverseCrossingTimes[crossingSegment]);
+      tSegmentTip = heCrossingTimes[crossingSegment];
+    }
+
+    double tBarySegment = (tBary - tSegmentTail) / (tSegmentTip - tSegmentTail);
+    Face inputFace = sharedFace(segmentTail, segmentTip);
+    Vector3 segmentTailCoords = segmentTail.inFace(inputFace).faceCoords;
+    Vector3 segmentTipCoords = segmentTip.inFace(inputFace).faceCoords;
+
+    return std::make_pair(
+        SurfacePoint(inputFace, (1 - tBarySegment) * segmentTailCoords + tBarySegment * segmentTipCoords),
+        crossingSegment);
+
+  } else if (normalCoordinates[he.edge()] < 0) {
+    // If this is a shared edge, return a point on the shared edge
+
+    SurfacePoint tail = vertexLocations[he.tailVertex()];
+    SurfacePoint tip = vertexLocations[he.tipVertex()];
+
+    Edge inputEdge;
+    if (tail.type == SurfacePointType::Edge) {
+      inputEdge = tail.edge;
+    } else if (tip.type == SurfacePointType::Edge) {
+      inputEdge = tip.edge;
+    } else {
+      inputEdge = getSharedInputEdge(he).edge();
+    }
+
+    double tTail = tail.inEdge(inputEdge).tEdge;
+    double tTip = tip.inEdge(inputEdge).tEdge;
+
+    return std::make_pair(SurfacePoint(inputEdge, (1 - tBary) * tTail + tBary * tTip), 0);
+  } else {
+    // The normal coordinate must be 0, meaning both endpoints are contained in a common face of the input mesh
+
+    SurfacePoint tail = vertexLocations[he.tailVertex()];
+    SurfacePoint tip = vertexLocations[he.tipVertex()];
+
+    Face inputFace = sharedFace(tail, tip);
+    if (inputFace == Face()) {
+      std::cout << he << " | normal coord: " << normalCoordinates[he.edge()] << std::endl;
+      std::cout << "Time to figure out what's going on" << std::endl;
+      std::cout << "tail: " << tail << std::endl;
+      std::cout << "tip: " << tip << std::endl;
+    }
+    GC_SAFETY_ASSERT(inputFace != Face(), "edge split err. Couldn't find shared parent face");
+    SurfacePoint tailInFace = tail.inFace(inputFace);
+    SurfacePoint tipInFace = tip.inFace(inputFace);
+
+    Vector3 tailCoords = tailInFace.faceCoords;
+    Vector3 tipCoords = tipInFace.faceCoords;
+
+    return std::make_pair(SurfacePoint(inputFace, (1 - tBary) * tailCoords + tBary * tipCoords), 0);
+  }
+}
+
 Vertex IntegerCoordinatesIntrinsicTriangulation::insertVertex(SurfacePoint pt) {
   Vertex newVertex;
   switch (pt.type) {
@@ -1244,35 +1248,16 @@ Vertex IntegerCoordinatesIntrinsicTriangulation::splitFace(Face f, Vector3 bary,
 }
 
 Halfedge IntegerCoordinatesIntrinsicTriangulation::splitEdge(Halfedge he, double tSplit) {
-  // FIXME need to  return correct halfedge, so can't just call function below
-  throw std::runtime_error("not implemented");
-  return Halfedge();
+  return (he.edge().isBoundary()) ? splitBoundaryEdge(he, tSplit) : splitInteriorEdge(he, tSplit);
 }
 
 Vertex IntegerCoordinatesIntrinsicTriangulation::splitEdge(Edge e, double bary, bool verbose) {
-  return (e.isBoundary()) ? splitBoundaryEdge(e, bary, verbose) : splitInteriorEdge(e, bary, verbose);
+  return (e.isBoundary()) ? splitBoundaryEdge(e.halfedge(), bary, verbose).vertex()
+                          : splitInteriorEdge(e.halfedge(), bary, verbose).vertex();
 }
 
-Vertex IntegerCoordinatesIntrinsicTriangulation::splitBoundaryEdge(Edge e, double bary, bool verbose) {
-  auto inEdge = [](Edge e, SurfacePoint p) -> SurfacePoint {
-    switch (p.type) {
-    case SurfacePointType::Vertex:
-      if (p.vertex == e.halfedge().tailVertex()) {
-        return SurfacePoint(e, 0);
-      } else if (p.vertex == e.halfedge().tipVertex()) {
-        return SurfacePoint(e, 1);
-      }
-      break;
-    case SurfacePointType::Edge:
-      if (p.edge == e) {
-        return p;
-      }
-      break;
-    default:
-      break;
-    }
-    throw std::runtime_error("SurfacePoint not in edge");
-  };
+Halfedge IntegerCoordinatesIntrinsicTriangulation::splitBoundaryEdge(Halfedge he, double bary, bool verbose) {
+  Edge e = he.edge();
 
   auto heBary = [&](Halfedge he, double t) -> Vector3 {
     int i = halfedgeIndexInTriangle(he);
@@ -1298,7 +1283,7 @@ Vertex IntegerCoordinatesIntrinsicTriangulation::splitBoundaryEdge(Edge e, doubl
                              "below for the == 0 case should be sufficient. But it's untested "
                              "for == 0, so uncomment this and try it.");
 
-    return Vertex();
+    return Halfedge();
 
     /*
     // Easy case - edge not shared
@@ -1308,13 +1293,13 @@ Vertex IntegerCoordinatesIntrinsicTriangulation::splitBoundaryEdge(Edge e, doubl
     // throw std::runtime_error("Not fully implemented yet - need to mark
     // split segments as fixed if e is");
 
-    Vertex vTipBefore  = e.halfedge().tipVertex();
-    Vertex vTailBefore = e.halfedge().tailVertex();
+    Vertex vTipBefore  = he.tipVertex();
+    Vertex vTailBefore = he.tailVertex();
     bool fixedBefore   = isFixed[e];
     isFixed[e]         = false;
 
     Vertex newVertex =
-        splitFace(e.halfedge().face(), heBary(e.halfedge(), bary));
+        splitFace(he.face(), heBary(he, bary));
     flipEdgeIfPossible(e);
 
 
@@ -1350,19 +1335,19 @@ Vertex IntegerCoordinatesIntrinsicTriangulation::splitBoundaryEdge(Edge e, doubl
     if (verbose) std::cout << "Shared Edge Split" << std::endl;
     // Hard case - edge also exists in input mesh
     Edge inputEdge;
-    SurfacePoint src = vertexLocations[e.halfedge().tailVertex()];
-    SurfacePoint dst = vertexLocations[e.halfedge().tipVertex()];
+    SurfacePoint src = vertexLocations[he.tailVertex()];
+    SurfacePoint dst = vertexLocations[he.tipVertex()];
 
     if (src.type == SurfacePointType::Edge) {
       inputEdge = src.edge;
     } else if (dst.type == SurfacePointType::Edge) {
       inputEdge = dst.edge;
     } else {
-      inputEdge = getSharedInputEdge(e.halfedge()).edge();
+      inputEdge = getSharedInputEdge(he).edge();
     }
 
-    double tSrc = inEdge(inputEdge, src).tEdge;
-    double tDst = inEdge(inputEdge, dst).tEdge;
+    double tSrc = src.inEdge(inputEdge).tEdge;
+    double tDst = dst.inEdge(inputEdge).tEdge;
 
     double tInsertion = (1 - bary) * tSrc + bary * tDst;
 
@@ -1373,8 +1358,7 @@ Vertex IntegerCoordinatesIntrinsicTriangulation::splitBoundaryEdge(Edge e, doubl
     // Compute new edge lengths
     double oldLen = edgeLengths[e];
     std::array<double, 3> newEdgeLengths{(1 - bary) * oldLen, 0, bary * oldLen};
-    newEdgeLengths[1] = displacementLength(heBary(e.halfedge(), bary) - heBary(e.halfedge().next(), 1),
-                                           faceEdgeLengths(e.halfedge().face()));
+    newEdgeLengths[1] = displacementLength(heBary(he, bary) - heBary(he.next(), 1), faceEdgeLengths(he.face()));
 
     std::array<bool, 3> newEdgeFixed{isFixed(e), false, isFixed(e)};
 
@@ -1433,32 +1417,25 @@ Vertex IntegerCoordinatesIntrinsicTriangulation::splitBoundaryEdge(Edge e, doubl
     updateHalfedgeVectorsInVertex(newVertex);
 
     triangulationChanged();
-    invokeEdgeSplitCallbacks(e, newHalfedge, newHalfedge.next().next().twin().next().next().twin());
 
-    return newVertex;
+    Halfedge otherNewHalfedge = newHalfedge.next().next().twin().next().next().twin();
+    if (e == he.edge()) {
+      invokeEdgeSplitCallbacks(e, newHalfedge, otherNewHalfedge);
+    } else {
+      invokeEdgeSplitCallbacks(e, otherNewHalfedge, newHalfedge);
+    }
+
+    return newHalfedge;
   }
 }
 
-Vertex IntegerCoordinatesIntrinsicTriangulation::splitInteriorEdge(Edge e, double bary, bool verbose) {
-  auto inEdge = [](Edge e, SurfacePoint p) -> SurfacePoint {
-    switch (p.type) {
-    case SurfacePointType::Vertex:
-      if (p.vertex == e.halfedge().tailVertex()) {
-        return SurfacePoint(e, 0);
-      } else if (p.vertex == e.halfedge().tipVertex()) {
-        return SurfacePoint(e, 1);
-      }
-      break;
-    case SurfacePointType::Edge:
-      if (p.edge == e) {
-        return p;
-      }
-      break;
-    default:
-      break;
-    }
-    throw std::runtime_error("SurfacePoint not in edge");
-  };
+Halfedge IntegerCoordinatesIntrinsicTriangulation::splitInteriorEdge(Halfedge he, double bary, bool verbose) {
+  Edge e = he.edge();
+
+  // verbose |= (he.getIndex() == 51146) || true;
+  if (verbose)
+    std::cout << "Splitting halfedge " << he << " | " << he.tailVertex() << " -> " << he.tipVertex() << "  at  " << bary
+              << std::endl;
 
   auto heBary = [&](Halfedge he, double t) -> Vector3 {
     int i = halfedgeIndexInTriangle(he);
@@ -1476,127 +1453,132 @@ Vertex IntegerCoordinatesIntrinsicTriangulation::splitInteriorEdge(Edge e, doubl
                    edgeLengths[f.halfedge().edge()]};
   };
 
+  SurfacePoint inputPoint;
+  size_t iSeg = 0;
   if (normalCoordinates[e] >= 0) {
-    if (verbose) std::cout << "Easy Edge Split" << std::endl;
-    // Easy case - edge not shared
-    // TODO: use normal coordinate edge split code explicitly - it
-    // needs fewer geodesic crossing points
-
-    Vertex vTipBefore = e.halfedge().tipVertex();
-    Vertex vTailBefore = e.halfedge().tailVertex();
-    bool fixedBefore = isFixed(e);
-
-    Vertex newVertex = splitFace(e.halfedge().face(), heBary(e.halfedge(), bary));
-    bool flipHappened = flipEdgeIfPossible(e);
-
-    if (!flipHappened) throw std::runtime_error("pos-split flip failed!");
-
-    // Find two of the halfedges that together make up the old edge
-    Halfedge newHalfedge = e.halfedge().prevOrbitFace().twin();
-    Halfedge otherNewHalfedge = newHalfedge.next().next().twin().next().next().twin();
-
-
-    // Update is-fixed array
-    // nsharp: don't need, we keep updated with edge split callback
-    // if (fixedBefore) {
-    // isFixed[newHalfedge.edge()] = true;
-    // isFixed[otherNewHalfedge.edge()] = true;
-    //}
-
-    triangulationChanged();
-    invokeEdgeSplitCallbacks(e, newHalfedge, otherNewHalfedge);
-
-    return newVertex;
-
+    if (verbose) std::cout << "     first" << std::endl;
+    // inputPoint = equivalentPointOnInput(SurfacePoint(he, bary));
+    std::tie(inputPoint, iSeg) = computeEdgeSplitData(he, bary);
   } else {
-    if (verbose) std::cout << "Shared Edge Split" << std::endl;
-    // Hard case - edge also exists in input mesh
+    if (verbose) std::cout << "     2nd" << std::endl;
     Edge inputEdge;
-    SurfacePoint src = vertexLocations[e.halfedge().tailVertex()];
-    SurfacePoint dst = vertexLocations[e.halfedge().tipVertex()];
+    SurfacePoint src = vertexLocations[he.tailVertex()];
+    SurfacePoint dst = vertexLocations[he.tipVertex()];
 
     if (src.type == SurfacePointType::Edge) {
       inputEdge = src.edge;
     } else if (dst.type == SurfacePointType::Edge) {
       inputEdge = dst.edge;
     } else {
-      inputEdge = getSharedInputEdge(e.halfedge()).edge();
+      inputEdge = getSharedInputEdge(he).edge();
     }
 
-    double tSrc = inEdge(inputEdge, src).tEdge;
-    double tDst = inEdge(inputEdge, dst).tEdge;
+    double tSrc = src.inEdge(inputEdge).tEdge;
+    double tDst = dst.inEdge(inputEdge).tEdge;
 
     double tInsertion = (1 - bary) * tSrc + bary * tDst;
 
-    SurfacePoint inputPoint(inputEdge, tInsertion);
+    inputPoint = SurfacePoint(inputEdge, tInsertion);
+    iSeg = 0;
+  }
 
-    std::array<int, 4> newNormalCoordinates = normalCoordinates.computeInteriorEdgeSplitDataGeodesic(*this, e, bary);
+  // fix orientation
+  if (he != e.halfedge()) {
+    bary = 1 - bary;
+    iSeg = normalCoordinates[e] - iSeg;
+  }
 
-    // Compute new edge lengths
-    double oldLen = edgeLengths[e];
-    std::array<double, 4> newEdgeLengths{0, (1 - bary) * oldLen, 0, bary * oldLen};
-    newEdgeLengths[0] =
-        displacementLength(heBary(e.halfedge().twin(), 1 - bary) - heBary(e.halfedge().twin().next(), 1),
-                           faceEdgeLengths(e.halfedge().twin().face()));
-    newEdgeLengths[2] = displacementLength(heBary(e.halfedge(), bary) - heBary(e.halfedge().next(), 1),
-                                           faceEdgeLengths(e.halfedge().face()));
+  if (verbose) std::cout << "  inputPoint: " << inputPoint << "\tiSeg: " << iSeg << std::endl;
 
-    std::array<bool, 4> newEdgeFixed{false, isFixed(e), false, isFixed(e)};
+  // std::array<int, 4> newNormalCoordinates = normalCoordinates.computeInteriorEdgeSplitDataGeodesic(*this, e, bary);
+  std::array<int, 4> newNormalCoordinates = normalCoordinates.computeInteriorEdgeSplitDataCombinatorial(*this, e, iSeg);
+  if (verbose)
+    std::cout << "  newNormalCoordinates: " << newNormalCoordinates[0] << ", " << newNormalCoordinates[1] << ", "
+              << newNormalCoordinates[2] << ", " << newNormalCoordinates[3] << std::endl;
 
-    // "edge 2"
-    Halfedge newHalfedge = intrinsicMesh->splitEdgeTriangular(e); // TODO: use mutation Manager
-    Vertex newVertex = newHalfedge.vertex();
-    vertexLocations[newVertex] = inputPoint;
+  // Compute new edge lengths
+  double oldLen = edgeLengths[e];
+  std::array<double, 4> newEdgeLengths{0, (1 - bary) * oldLen, 0, bary * oldLen};
+  newEdgeLengths[0] = displacementLength(heBary(e.halfedge().twin(), 1 - bary) - heBary(e.halfedge().twin().next(), 1),
+                                         faceEdgeLengths(e.halfedge().twin().face()));
+  newEdgeLengths[2] = displacementLength(heBary(e.halfedge(), bary) - heBary(e.halfedge().next(), 1),
+                                         faceEdgeLengths(e.halfedge().face()));
 
-    // TODO: write applyVertexInsertionData in NormalCoordinates
-    // class
+  std::array<bool, 4> newEdgeFixed{false, isFixed(e), false, isFixed(e)};
 
-    size_t iE = 1; // TODO: fix indexing convention
-    for (Halfedge he : newVertex.outgoingHalfedges()) {
-      Edge e = he.edge();
+  // "edge 2"
+  Halfedge newHalfedge = intrinsicMesh->splitEdgeTriangular(e); // TODO: use mutation Manager
+  Vertex newVertex = newHalfedge.vertex();
+  vertexLocations[newVertex] = inputPoint;
 
-      edgeLengths[e] = newEdgeLengths[iE];
-      normalCoordinates.edgeCoords[e] = newNormalCoordinates[iE];
+  if (verbose) {
+    auto faceString = [&](Face f) -> std::string {
+      std::string name = "{";
+      for (Vertex v : f.adjacentVertices()) {
+        name += std::to_string(v.getIndex());
+        name += ", ";
+      }
+      name += "}";
+      return name;
+    };
+    std::cout << "Inserted new vertex " << newVertex << ". The adjacent faces are: " << std::endl;
+    for (Face f : newVertex.adjacentFaces()) std::cout << "\t" << f << " " << faceString(f) << std::endl;
+  }
 
-      // nsharp: don't need this, managed by callback
-      // if (!isFixed[e] && newEdgeFixed[iE]) {
-      // isFixed[e] = true;
-      //// fixedEdges.push_back(e);
-      //} else if (isFixed[e] && !newEdgeFixed[iE]) {
-      // throw std::runtime_error("Need to remove e from the fixed list");
-      //}
+  // TODO: write applyVertexInsertionData in NormalCoordinates
+  // class
 
-      // indexing goes counterclockwise, but loop goes clockwise
-      iE = (iE + 3) % 4;
-    }
+  size_t iE = 1; // TODO: fix indexing convention
+  for (Halfedge he : newVertex.outgoingHalfedges()) {
+    Edge e = he.edge();
 
-    for (Halfedge he : newVertex.outgoingHalfedges()) {
-      // depends on normalCoordinates.edgeCoords
-      normalCoordinates.setRoundaboutFromPrevRoundabout(he.twin());
-      normalCoordinates.roundabouts[he] = 0;
-    }
-    normalCoordinates.roundaboutDegrees[newVertex] = 0;
+    edgeLengths[e] = newEdgeLengths[iE];
+    normalCoordinates.edgeCoords[e] = newNormalCoordinates[iE];
 
-    // Update quantities
+    // nsharp: don't need this, managed by callback
+    // if (!isFixed[e] && newEdgeFixed[iE]) {
+    // isFixed[e] = true;
+    //// fixedEdges.push_back(e);
+    //} else if (isFixed[e] && !newEdgeFixed[iE]) {
+    // throw std::runtime_error("Need to remove e from the fixed list");
+    //}
 
-    for (Face f : newVertex.adjacentFaces()) {
+    // indexing goes counterclockwise, but loop goes clockwise
+    iE = (iE + 3) % 4;
+  }
 
-      // depends on edgeLengths, faceAreas
-      updateFaceBasis(f);
-    }
+  for (Halfedge he : newVertex.outgoingHalfedges()) {
+    // depends on normalCoordinates.edgeCoords
+    normalCoordinates.setRoundaboutFromPrevRoundabout(he.twin());
+    normalCoordinates.roundabouts[he] = 0;
+  }
+  normalCoordinates.roundaboutDegrees[newVertex] = 0;
 
-    for (Vertex v : newVertex.adjacentVertices()) {
-      // depends on vertexAngleSums
-      updateHalfedgeVectorsInVertex(v);
-    }
+  // Update quantities
 
-    vertexAngleSums[newVertex] = 2 * M_PI;
-    updateHalfedgeVectorsInVertex(newVertex);
+  for (Face f : newVertex.adjacentFaces()) {
 
-    triangulationChanged();
-    invokeEdgeSplitCallbacks(e, newHalfedge, newHalfedge.next().next().twin().next().next().twin());
+    // depends on edgeLengths, faceAreas
+    updateFaceBasis(f);
+  }
 
-    return newVertex;
+  for (Vertex v : newVertex.adjacentVertices()) {
+    // depends on vertexAngleSums
+    updateHalfedgeVectorsInVertex(v);
+  }
+
+  vertexAngleSums[newVertex] = 2 * M_PI;
+  updateHalfedgeVectorsInVertex(newVertex);
+
+  triangulationChanged();
+
+  Halfedge otherNewHalfedge = newHalfedge.next().next().twin().next().next().twin();
+  if (e == he.edge()) {
+    invokeEdgeSplitCallbacks(e, newHalfedge, otherNewHalfedge);
+    return newHalfedge;
+  } else {
+    invokeEdgeSplitCallbacks(e, otherNewHalfedge, newHalfedge);
+    return otherNewHalfedge;
   }
 }
 
@@ -2085,6 +2067,8 @@ Face IntegerCoordinatesIntrinsicTriangulation::getParentFace(Face f) const {
       // Check if this works for everyone else
       for (Vertex w : f.adjacentVertices()) {
         if (!compatible(vertexLocations[w], parentFace)) {
+          std::cout << "Big problem: " << v << " lies at " << vP << ", but " << w << " is located at "
+                    << vertexLocations[w] << " which is not compatible" << std::endl;
           return Face();
         }
       }
@@ -2112,7 +2096,18 @@ Face IntegerCoordinatesIntrinsicTriangulation::getParentFace(Face f) const {
     }
   }
 
-  // Give up
+  // All vertices are shared. Just return any face which contains these three vertices.
+  // TODO: in really extreme delta complexes, this could give the wrong result
+  Vertex u = vertexLocations[f.halfedge().vertex()].vertex;
+  Vertex v = vertexLocations[f.halfedge().next().vertex()].vertex;
+  Vertex w = vertexLocations[f.halfedge().next().next().vertex()].vertex;
+
+  for (Face f : u.adjacentFaces()) {
+    if (containsVertex(f, v) && containsVertex(f, w)) return f;
+  }
+
+  // Give up. Something has gone terribly wrong
+  std::cout << "!!??" << std::endl;
   return Face();
 }
 

--- a/src/surface/intrinsic_triangulation.cpp
+++ b/src/surface/intrinsic_triangulation.cpp
@@ -58,6 +58,8 @@ void IntrinsicTriangulation::setMarkedEdges(const EdgeData<bool>& markedEdges_) 
   markedEdges.setDefault(false);
 }
 
+void IntrinsicTriangulation::clearMarkedEdges() { markedEdges = EdgeData<bool>(); }
+
 // ======================================================
 // ======== Queries & Accessors
 // ======================================================
@@ -184,6 +186,25 @@ Face IntrinsicTriangulation::getParentFace(Face f) const {
   return Face();
 }
 
+double IntrinsicTriangulation::getCornerAngle(Corner c) const {
+  Halfedge heA = c.halfedge();
+  Halfedge heOpp = heA.next();
+  Halfedge heB = heOpp.next();
+
+  GC_SAFETY_ASSERT(heB.next() == heA, "faces mush be triangular");
+
+  double lOpp = edgeLengths[heOpp.edge()];
+  double lA = edgeLengths[heA.edge()];
+  double lB = edgeLengths[heB.edge()];
+
+  double angleCosine = (lA * lA + lB * lB - lOpp * lOpp) / (2. * lA * lB);
+  angleCosine = clamp(angleCosine, -1.0, 1.0);
+
+  double angle = std::acos(angleCosine);
+
+  return angle;
+}
+
 double IntrinsicTriangulation::minAngleDegreesAtValidFaces(double minAngleSum) const {
   auto faceHasLargeAngleSums = [&](Face f) -> bool {
     for (Vertex v : f.adjacentVertices()) {
@@ -269,6 +290,37 @@ Vertex IntrinsicTriangulation::insertBarycenter(Face f) {
   return insertVertex(barycenterOnIntrinsic);
 }
 
+std::vector<double> IntrinsicTriangulation::recoverTraceTValues(const std::vector<SurfacePoint>& edgeTrace) {
+  std::vector<double> tVals(edgeTrace.size());
+
+  // Walk along the curve, measuring the length of each segment from its barcentric coordinates and the geometry of the
+  // underlying triangulation
+  tVals[0] = 0.;
+  for (size_t iP = 0; iP + 1 < edgeTrace.size(); iP++) {
+    SurfacePoint prev = edgeTrace[iP];
+    SurfacePoint next = edgeTrace[iP + 1];
+    Face f = sharedFace(prev, next);
+    prev = prev.inFace(f);
+    next = next.inFace(f);
+
+    // lengths[i] is the length of the edge opposite the i'th vertex
+    Vector3 triangleLengths{inputGeom.edgeLengths[f.halfedge().next().edge()],
+                            inputGeom.edgeLengths[f.halfedge().next().next().edge()],
+                            inputGeom.edgeLengths[f.halfedge().edge()]};
+    Vector3 disp = next.faceCoords - prev.faceCoords;
+    double len = displacementLength(disp, triangleLengths);
+    tVals[iP + 1] = tVals[iP] + len;
+  }
+
+  // normalize to [0,1]
+  double totalLen = tVals.back();
+  for (double& t : tVals) {
+    t /= totalLen;
+  }
+
+  return tVals;
+}
+
 // ======================================================
 // ======== High-Level Mutators
 // ======================================================
@@ -325,9 +377,33 @@ void IntrinsicTriangulation::delaunayRefine(double angleThreshDegrees, double ci
   // Build a function to test if a face violates the circumradius ratio condition
   auto needsCircumcenterRefinement = [&](Face f) {
     size_t nNeedle = 0;
-    for (Vertex v : f.adjacentVertices()) {
-      if (vertexAngleSums[v] < M_PI / 3.) nNeedle++;
+    // for (Vertex v : f.adjacentVertices()) {
+    //   if (vertexAngleSums[v] < M_PI / 3.) nNeedle++;
+    // }
+    // std::cout << "face check begin" << std::endl;
+    for (Halfedge he : f.adjacentHalfedges()) {
+      double angleSum = 0;
+      Halfedge heCurr = he;
+      // std::cout << "Loop 1 begin" << std::endl;
+      do {
+        angleSum += cornerAngle(heCurr.corner());
+        heCurr = heCurr.next().next().twin();
+      } while (heCurr != he && !isFixed(heCurr.edge()));
+      // std::cout << "Loop 1 end" << std::endl;
+
+      if (heCurr != he && !isFixed(he.edge())) {
+        // std::cout << "Loop 2 begin" << std::endl;
+        heCurr = he;
+        do {
+          heCurr = heCurr.twin().next();
+          angleSum += cornerAngle(heCurr.corner());
+        } while (!isFixed(heCurr.edge()));
+        // std::cout << "Loop 2 end" << std::endl;
+      }
+
+      if (angleSum < M_PI / 3.) nNeedle++;
     }
+    // std::cout << "face check end" << std::endl;
     if (nNeedle == 1) return false;
 
     Face inputFace = getParentFace(f);

--- a/src/surface/normal_coordinates.cpp
+++ b/src/surface/normal_coordinates.cpp
@@ -233,6 +233,44 @@ std::array<int, 4> NormalCoordinates::computeInteriorEdgeSplitDataGeodesic(Intri
   }
 }
 
+std::array<int, 4> NormalCoordinates::computeInteriorEdgeSplitDataCombinatorial(IntrinsicGeometryInterface& geo, Edge e,
+                                                                                size_t iSeg) {
+  if (edgeCoords[e] > 0) {
+    int n2 = edgeCoords[e] - iSeg;
+    int n4 = iSeg;
+
+    Corner ck = e.halfedge().next().next().corner();
+    Corner cl = e.halfedge().twin().next().next().corner();
+
+    int n1 = 0;
+    n1 += positivePart(strictCornerCoord(e.halfedge().twin().corner()) - positivePart(n2));
+    n1 += positivePart(strictCornerCoord(e.halfedge().twin().next().corner()) - positivePart(n4));
+    n1 += strictCornerCoord(cl);
+    n1 += strictDegree(e.halfedge().twin().corner());
+    n1 += strictDegree(e.halfedge().twin().next().corner());
+
+    int n3 = 0;
+    n3 += positivePart(strictCornerCoord(e.halfedge().next().corner()) - positivePart(n2));
+    n3 += positivePart(strictCornerCoord(e.halfedge().corner()) - positivePart(n4));
+    n3 += strictCornerCoord(ck);
+    n3 += strictDegree(e.halfedge().corner());
+    n3 += strictDegree(e.halfedge().next().corner());
+
+    return {n1, n2, n3, n4};
+  } else {
+    int nil = edgeCoords[e.halfedge().twin().next().edge()];
+    int nlj = edgeCoords[e.halfedge().twin().next().next().edge()];
+    int njk = edgeCoords[e.halfedge().next().edge()];
+    int nki = edgeCoords[e.halfedge().next().next().edge()];
+
+    int n1 = fmax(nil, fmax(nlj, 0));
+    int n2 = edgeCoords[e];
+    int n3 = fmax(njk, fmax(nki, 0));
+    int n4 = edgeCoords[e];
+    return {n1, n2, n3, n4};
+  }
+}
+
 std::array<int, 3> NormalCoordinates::computeBoundaryEdgeSplitDataGeodesic(IntrinsicGeometryInterface& geo, Edge e,
                                                                            double location) {
 
@@ -837,7 +875,8 @@ std::vector<SurfacePoint> generateSingleGeodesicGeometry(ManifoldSurfaceMesh& me
 // Barycentric coordinates are 0 at the src of and edge and 1 at the dst
 std::vector<std::pair<SurfacePoint, double>> generateFullSingleGeodesicGeometry(ManifoldSurfaceMesh& mesh,
                                                                                 IntrinsicGeometryInterface& geo,
-                                                                                const NormalCoordinatesCurve& curve) {
+                                                                                const NormalCoordinatesCurve& curve,
+                                                                                bool verbose) {
 
   // == Compute a geodesic path by laying the triangle strip that the path
   // passes through out in the plane
@@ -972,6 +1011,14 @@ std::vector<std::pair<SurfacePoint, double>> generateFullSingleGeodesicGeometry(
   Halfedge heEnd = std::get<1>(curve.crossings[curve.crossings.size() - 1]);
   SurfacePoint vEnd(heEnd.twin().next().next().vertex());
 
+  if (verbose) {
+    std::cout << "start: " << start << std::endl;
+    for (const auto& positions : edgePositions) {
+      std::cout << "  " << positions[0] << "   |   " << positions[1] << std::endl;
+    }
+    std::cout << "end: " << start << std::endl;
+  }
+
   std::vector<std::pair<SurfacePoint, double>> embeddedCurve{std::make_pair(vStart, 0)};
 
   for (size_t iC = 0; iC < curve.crossings.size(); ++iC) {
@@ -982,10 +1029,17 @@ std::vector<std::pair<SurfacePoint, double>> generateFullSingleGeodesicGeometry(
     double tA = intersection.tA;
     double tB = intersection.tB;
 
+    if (verbose) {
+      std::cout << tA << ", " << tB << std::endl;
+    }
+
     tA = clamp(tA, 0., 1.);
     tB = clamp(tB, 0., 1.);
 
     embeddedCurve.push_back(std::make_pair(SurfacePoint{he, tA}, tB));
+  }
+  if (verbose) {
+    std::cout << std::endl;
   }
 
   embeddedCurve.push_back(std::make_pair(vEnd, 1));

--- a/src/surface/signpost_intrinsic_triangulation.cpp
+++ b/src/surface/signpost_intrinsic_triangulation.cpp
@@ -269,6 +269,7 @@ SurfacePoint SignpostIntrinsicTriangulation::equivalentPointOnInput(const Surfac
 // ======== Queries & Accessors
 // ======================================================
 
+bool SignpostIntrinsicTriangulation::checkEdgeOriginal(Edge e) const { return edgeIsOriginal[e]; }
 
 // ======================================================
 // ======== Mutators
@@ -735,7 +736,6 @@ void SignpostIntrinsicTriangulation::resolveNewVertex(Vertex newV, SurfacePoint 
     outgoingVec = -inputTraceResult.endingDir;
   }
 
-
   // Set the location of our newly inserted vertex
   vertexLocations[newV] = newPositionOnInput;
 
@@ -757,35 +757,6 @@ void SignpostIntrinsicTriangulation::resolveNewVertex(Vertex newV, SurfacePoint 
     if (!currHe.isInterior()) break;
     currHe = currHe.next().next().twin();
   } while (currHe != firstHe);
-}
-
-std::vector<double> SignpostIntrinsicTriangulation::recoverTraceTValues(const std::vector<SurfacePoint>& edgeTrace) {
-  std::vector<double> tVals(edgeTrace.size());
-
-  // Walk along the curve, measuring the length of each segment from its barcentric coordinates and the geometry of the
-  // underlying triangulation
-  tVals[0] = 0.;
-  for (size_t iP = 1; iP + 1 < edgeTrace.size(); iP++) {
-    SurfacePoint prev = edgeTrace[iP - 1];
-    SurfacePoint next = edgeTrace[iP];
-    Face f = sharedFace(prev, next);
-    prev = prev.inFace(f);
-    next = next.inFace(f);
-    Vector3 triangleLengths{inputGeom.edgeLengths[f.halfedge().edge()],
-                            inputGeom.edgeLengths[f.halfedge().next().edge()],
-                            inputGeom.edgeLengths[f.halfedge().next().next().edge()]};
-    Vector3 disp = next.faceCoords - prev.faceCoords;
-    double len = displacementLength(disp, triangleLengths);
-    tVals[iP] = tVals[iP - 1] + len;
-  }
-
-  // normalize to [0,1]
-  double totalLen = tVals.back();
-  for (double& t : tVals) {
-    t /= totalLen;
-  }
-
-  return tVals;
 }
 
 void SignpostIntrinsicTriangulation::constructCommonSubdivision() {


### PR DESCRIPTION
Here are a few bug fixes/quality of life improvements for integer coordinates intrinsic triangulations.

1. Now the integer coordinate `splitEdge` function takes a halfedge rather than an edge, and returns the halfedge incident on the inserted vertex which points in the same direction. (I think this was always the desired behavior for `IntrinsicTriangulation`s, but integer coordinates didn't quite keep track of all the orientations properly 😛)
2. I moved `recoverTraceTValues` (the function for computing barycentric coordinates along a traced edge) into `IntrinsicTriangulation` rather than keeping it as a member of `SignpostIntrinsicTriangulation` in particular. I also fixed an off-by-one error which made all the barycentric coordinates wrong.
3. I added some code to explicitly update integer coordinates data following an edge split, rather than just doing a face split followed by an edge flip. This made the orientation handling in point 1 more straightforward.
4. I added a function to `IntrinsicTriangulation` to check if an edge is shared with the original mesh. Both types of intrinsic triangulation already supported this query, so it seemed nice to add to the higher-level interface.
5. To support some of the other calculations, I added an `inEdge(Edge e)` function for `SurfacePoints` which functions like `inFace(Face f)`.