### PR TITLE
typo in error messages

### DIFF
--- a/include/geometrycentral/surface/edge_length_geometry.ipp
+++ b/include/geometrycentral/surface/edge_length_geometry.ipp
@@ -15,7 +15,7 @@ inline double EdgeLengthGeometry::faceArea(Face f) const {
   he = he.next();
   double c = edgeLengths[he.edge()];
 
-  GC_SAFETY_ASSERT(he.next() == f.halfedge(), "faces mush be triangular");
+  GC_SAFETY_ASSERT(he.next() == f.halfedge(), "faces must be triangular");
 
   // Heron's formula
   double s = (a + b + c) / 2.0;
@@ -42,7 +42,7 @@ inline double EdgeLengthGeometry::cornerAngle(Corner c) const {
   Halfedge heOpp = heA.next();
   Halfedge heB = heOpp.next();
 
-  GC_SAFETY_ASSERT(heB.next() == heA, "faces mush be triangular");
+  GC_SAFETY_ASSERT(heB.next() == heA, "faces must be triangular");
 
   double lOpp = edgeLengths[heOpp.edge()];
   double lA = edgeLengths[heA.edge()];
@@ -68,7 +68,7 @@ inline double EdgeLengthGeometry::halfedgeCotanWeight(Halfedge heI) const {
     he = he.next();
     double l_ki = edgeLengths[he.edge()];
     he = he.next();
-    GC_SAFETY_ASSERT(he == heI, "faces mush be triangular");
+    GC_SAFETY_ASSERT(he == heI, "faces must be triangular");
     double area = faceArea(he.face());
     double cotValue = (-l_ij * l_ij + l_jk * l_jk + l_ki * l_ki) / (4. * area);
     return cotValue / 2;

--- a/include/geometrycentral/surface/vertex_position_geometry.ipp
+++ b/include/geometrycentral/surface/vertex_position_geometry.ipp
@@ -64,7 +64,7 @@ inline double VertexPositionGeometry::cornerAngle(Corner c) const {
   he = he.next();
   Vector3 pC = vertexPositions[he.vertex()];
 
-  GC_SAFETY_ASSERT(he.next() == c.halfedge(), "faces mush be triangular");
+  GC_SAFETY_ASSERT(he.next() == c.halfedge(), "faces must be triangular");
 
   double q = dot(unit(pB - pA), unit(pC - pA));
   q = clamp(q, -1.0, 1.0);

--- a/src/surface/intrinsic_geometry_interface.cpp
+++ b/src/surface/intrinsic_geometry_interface.cpp
@@ -69,7 +69,7 @@ void IntrinsicGeometryInterface::computeFaceAreas() {
     he = he.next();
     double c = edgeLengths[he.edge()];
 
-    GC_SAFETY_ASSERT(he.next() == f.halfedge(), "faces mush be triangular");
+    GC_SAFETY_ASSERT(he.next() == f.halfedge(), "faces must be triangular");
 
     // Herons formula
     double s = (a + b + c) / 2.0;
@@ -112,7 +112,7 @@ void IntrinsicGeometryInterface::computeCornerAngles() {
     Halfedge heOpp = heA.next();
     Halfedge heB = heOpp.next();
 
-    GC_SAFETY_ASSERT(heB.next() == heA, "faces mush be triangular");
+    GC_SAFETY_ASSERT(heB.next() == heA, "faces must be triangular");
 
     double lOpp = edgeLengths[heOpp.edge()];
     double lA = edgeLengths[heA.edge()];
@@ -192,7 +192,7 @@ void IntrinsicGeometryInterface::computeFaceGaussianCurvatures() {
       angleDefect += cornerScaledAngles[he.corner()];
       he = he.next();
     }
-    GC_SAFETY_ASSERT(he == f.halfedge(), "faces mush be triangular");
+    GC_SAFETY_ASSERT(he == f.halfedge(), "faces must be triangular");
 
     faceGaussianCurvatures[f] = angleDefect;
   }
@@ -217,7 +217,7 @@ void IntrinsicGeometryInterface::computeHalfedgeCotanWeights() {
     double l_ki = edgeLengths[heF.edge()];
     heF = heF.next();
 
-    GC_SAFETY_ASSERT(heF == he, "faces mush be triangular");
+    GC_SAFETY_ASSERT(heF == he, "faces must be triangular");
 
     double area = faceAreas[he.face()];
     double cotValue = (-l_ij * l_ij + l_jk * l_jk + l_ki * l_ki) / (4. * area);
@@ -245,7 +245,7 @@ void IntrinsicGeometryInterface::computeEdgeCotanWeights() {
       he = he.next();
       double l_ki = edgeLengths[he.edge()];
       he = he.next();
-      GC_SAFETY_ASSERT(he == heFirst, "faces mush be triangular");
+      GC_SAFETY_ASSERT(he == heFirst, "faces must be triangular");
       double area = faceAreas[he.face()];
       double cotValue = (-l_ij * l_ij + l_jk * l_jk + l_ki * l_ki) / (4. * area);
       cotSum += cotValue / 2;

--- a/src/surface/intrinsic_triangulation.cpp
+++ b/src/surface/intrinsic_triangulation.cpp
@@ -191,7 +191,7 @@ double IntrinsicTriangulation::getCornerAngle(Corner c) const {
   Halfedge heOpp = heA.next();
   Halfedge heB = heOpp.next();
 
-  GC_SAFETY_ASSERT(heB.next() == heA, "faces mush be triangular");
+  GC_SAFETY_ASSERT(heB.next() == heA, "faces must be triangular");
 
   double lOpp = edgeLengths[heOpp.edge()];
   double lA = edgeLengths[heA.edge()];

--- a/src/surface/normal_coordinates.cpp
+++ b/src/surface/normal_coordinates.cpp
@@ -892,7 +892,7 @@ std::vector<std::pair<SurfacePoint, double>> generateFullSingleGeodesicGeometry(
     Halfedge heOpp = heA.next();
     Halfedge heB = heOpp.next();
 
-    GC_SAFETY_ASSERT(heB.next() == heA, "faces mush be triangular");
+    GC_SAFETY_ASSERT(heB.next() == heA, "faces must be triangular");
 
     double lOpp = geo.edgeLengths[heOpp.edge()];
     double lA = geo.edgeLengths[heA.edge()];

--- a/src/surface/simple_idt.cpp
+++ b/src/surface/simple_idt.cpp
@@ -72,7 +72,7 @@ size_t flipToDelaunay(SurfaceMesh& mesh, EdgeData<double>& edgeLengths, FlipType
       he = he.next();
       double l_ki = edgeLengths[he.edge()];
       he = he.next();
-      GC_SAFETY_ASSERT(he == heI, "faces mush be triangular");
+      GC_SAFETY_ASSERT(he == heI, "faces must be triangular");
       double areaV = area(he.face());
       double cotValue = (-l_ij * l_ij + l_jk * l_jk + l_ki * l_ki) / (4. * areaV);
       return cotValue / 2;


### PR DESCRIPTION
it is the same one as before in "faces mush be triangular", I'm sorry that I didn't use *find & replace* on it across all files as I didn't think it was the same message in all these files.