### PR TITLE
Fixing more 404 links in docs and removing an empty page

### DIFF
--- a/docs/docs/numerical/linear_solvers.md
+++ b/docs/docs/numerical/linear_solvers.md
@@ -10,7 +10,7 @@ These solvers provide a simple interface for solving sparse linear $Ax = b$.
 
 A key feature is that these solvers abstract over the underlying numerical library. In their most basic form, [Eigen's sparse solvers](https://eigen.tuxfamily.org/dox/group__TopicSparseSystems.html) will be used, and are always available. However, if present, the more-powerful [Suitesprase solvers](http://faculty.cse.tamu.edu/davis/suitesparse.html) will be used intead. See the [dependencies section](../../build/dependencies/#suitesparse) for instruction to build with Suitesparse support.
 
-As always, be sure to compile [with optimizations](../../build/build/#compiling-with-optimizations) for meaningful performance. In particular, Eigen's built-in solvers will be very slow in debug mode (though the Eigen QR solver is always slow).
+As always, be sure to compile [with optimizations](../../build/building/#compile-flags-options) for meaningful performance. In particular, Eigen's built-in solvers will be very slow in debug mode (though the Eigen QR solver is always slow).
 
 ### Quick solves
 

--- a/docs/docs/pointcloud/utilities/sampling.md
+++ b/docs/docs/pointcloud/utilities/sampling.md
@@ -46,5 +46,5 @@ PointPositionGeometry cloudGeom(*cloud, pointPos);
     - A `SurfacePoint` on the original mesh corresponding to each point
 
 
-Note that in addition to the cloud and 3D positions, this routine returns a `SurfacePoint` associated with each point sample. The [surface point](surface/utilities/surface_point) is a handy class representing a location on the underlying mesh, and makes it easy to do things like interpolate data defined on the source mesh, or grab face normals, etc.
+Note that in addition to the cloud and 3D positions, this routine returns a `SurfacePoint` associated with each point sample. The [surface point](/surface/utilities/surface_point/) is a handy class representing a location on the underlying mesh, and makes it easy to do things like interpolate data defined on the source mesh, or grab face normals, etc.
 

--- a/docs/docs/surface/intrinsic_triangulations/basics.md
+++ b/docs/docs/surface/intrinsic_triangulations/basics.md
@@ -218,7 +218,7 @@ Note that some additional functions and members can be found in the `IntrinsicTr
 
 !!! note "Refreshing quantities"
 
-    The intrinsic triangulation is-a [geometry](../surface/geometry) object, which means that one may `require()` quantities from it. However, for efficiency reasons, these quantities are not automatically updated after each low-level mutataion. Call `refreshQuantities()` after a sequence of mutations to update.
+    The intrinsic triangulation is-a [geometry](/surface/geometry/geometry/) object, which means that one may `require()` quantities from it. However, for efficiency reasons, these quantities are not automatically updated after each low-level mutataion. Call `refreshQuantities()` after a sequence of mutations to update.
   
 
 ??? func "`#!cpp bool IntrinsicTriangulation::flipEdgeIfNotDelaunay(Edge e)`"

--- a/docs/docs/utilities/indexing.md
+++ b/docs/docs/utilities/indexing.md
@@ -94,7 +94,7 @@ These methods build and return an `ElementData<size_t>` array that indexes the m
 ## Per element indices
 
 !!! warning
-    The routines in this section are valid only when the mesh is [compressed](mutation.md#compressed-mode).
+    The routines in this section are valid only when the mesh is [compressed](/surface/surface_mesh/mutation/#compressed-mode).
 
 These methods access the index directly from the mesh element itself.  For example:
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -79,7 +79,6 @@ nav:
       - 'Vector Heat Method' : 'surface/algorithms/vector_heat_method.md'
       - 'Surface Centers' : 'surface/algorithms/surface_centers.md'
       - 'Geodesic Centroidal Voronoi Tessellations' : 'surface/algorithms/geodesic_voronoi_tessellations.md'
-      - 'Mesh Graph Algorithms' : 'surface/algorithms/mesh_graph_algorithms.md'
       - 'Robust Geometry' : 'surface/algorithms/robust_geometry.md'
       - 'Flip Geodesics' : 'surface/algorithms/flip_geodesics.md'
       - 'Parameterization' : 'surface/algorithms/parameterization.md'


### PR DESCRIPTION
In this commit, I have gone through all pages in docs and fixed the broken links. I might have missed something, though.

Also,  here are 2 more links that I did not know what to do with:
In the [index page](https://geometry-central.net/), Yousuf Soliman's link is broken but I can't find a good alternative.
The [indexing page in utilities](https://geometry-central.net/utilities/indexing/) is not referenced in the navigation. But I don't know if that's intentional.