### PR TITLE
Cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,3 +49,16 @@ SET(GC_HAVE_SUITESPARSE ${GC_HAVE_SUITESPARSE} PARENT_SCOPE)
 
 ### Recurse to the source code
 add_subdirectory(src)
+
+# install
+install(
+  TARGETS geometry-central
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib)
+
+install(
+  DIRECTORY ${CMAKE_SOURCE_DIR}/include/
+  DESTINATION include
+  FILES_MATCHING
+  PATTERN "*.h")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,4 +61,5 @@ install(
   DIRECTORY ${CMAKE_SOURCE_DIR}/include/
   DESTINATION include
   FILES_MATCHING
-  PATTERN "*.h")
+  PATTERN "*.h"
+  PATTERN "*.ipp")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -180,3 +180,8 @@ if(GC_HAVE_SUITESPARSE)
   target_include_directories(geometry-central PRIVATE ${SUITESPARSE_INCLUDE_DIRS})
   target_link_libraries(geometry-central PRIVATE ${SUITESPARSE_LIBRARIES})
 endif()
+
+# Export symbols if DLL is requested
+if(MSVC AND BUILD_SHARED_LIBS)
+  set_target_properties(geometry-central PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()


### PR DESCRIPTION
Thie PR adds the following
- install target installs the library and header files to `CMAKE_INSTALL_PREFIX`
- if user requests `BUILD_SHARED_LIBS` for a `MSVC` build symbols are automatically exported