### PR TITLE
Nonmanifold mmp

### DIFF
--- a/include/geometrycentral/surface/exact_geodesics.h
+++ b/include/geometrycentral/surface/exact_geodesics.h
@@ -140,7 +140,7 @@ protected:
 
   SortedSources m_sources;
 
-  VertexData<bool> vertexIsManifold;
+  VertexData<bool> vertexIsManifold, vertexIsBoundary;
 };
 
 } // namespace surface

--- a/include/geometrycentral/surface/halfedge_element_types.ipp
+++ b/include/geometrycentral/surface/halfedge_element_types.ipp
@@ -35,8 +35,17 @@ inline Corner Vertex::corner() const        { return halfedge().corner(); }
 inline bool Vertex::isDead() const          { return mesh->vertexIsDead(ind); }
 
 // Properties
-inline bool Vertex::isBoundary() const { return !halfedge().twin().isInterior(); }
-inline bool Vertex::isManifoldAndOriented() const { 
+inline bool Vertex::isBoundary() const {
+  if(mesh->usesImplicitTwin()) {
+    return !halfedge().twin().isInterior();
+  } else {
+    for (Edge e : adjacentEdges()) {
+      if (e.isBoundary()) {return true;}
+    }
+    return false;
+  }
+}
+inline bool Vertex::isManifoldAndOriented() const {
   // TODO this routine is actually pretty nontrivial, it probably deserves some more thought
   // strategy: bootstrap off of the adjacency iterator, which already has functionality for nonmanifold vertices
   if(mesh->usesImplicitTwin()) return true;

--- a/include/geometrycentral/surface/surface_mesh.h
+++ b/include/geometrycentral/surface/surface_mesh.h
@@ -123,6 +123,8 @@ public:
   virtual EdgeData<bool> getEdgeManifoldStatus();
   virtual EdgeData<bool> getEdgeOrientedStatus();
 
+  VertexData<bool> getVertexBoundaryStatus();
+
   // Mesh helper utilities
   Edge connectingEdge(Vertex vA, Vertex vB); // an edge from vA -- vB if one exists; Edge() otherwise
 

--- a/src/surface/exact_geodesics.cpp
+++ b/src/surface/exact_geodesics.cpp
@@ -448,7 +448,6 @@ void GeodesicAlgorithmExact::propagate(const std::vector<SurfacePoint>& sources,
       bool saddle = geom.vertexGaussianCurvatures[v] < 0;
       geom.unrequireVertexGaussianCurvatures();
       return saddle || vertexIsBoundary[v];
-      // return saddle;
     };
 
     bool const turn_left = saddleOrBoundary(he.tailVertex());

--- a/src/surface/exact_geodesics.cpp
+++ b/src/surface/exact_geodesics.cpp
@@ -24,6 +24,7 @@ GeodesicAlgorithmExact::GeodesicAlgorithmExact(SurfaceMesh& mesh_, IntrinsicGeom
 
   // Cache vertex manifold status so we don't have to repeatedly check vertices
   vertexIsManifold = mesh.getVertexManifoldStatus();
+  vertexIsBoundary = mesh.getVertexBoundaryStatus();
 };
 
 // == Adapters for various input types
@@ -102,8 +103,10 @@ void GeodesicAlgorithmExact::possible_traceback_edges(SurfacePoint& point, std::
   }
   case SurfacePointType::Edge: {
     for (Halfedge he : point.edge.adjacentHalfedges()) {
-      storage.push_back(he.next().edge());
-      storage.push_back(he.next().next().edge());
+      if (he.isInterior()) {
+        storage.push_back(he.next().edge());
+        storage.push_back(he.next().next().edge());
+      }
     }
     break;
   }
@@ -444,7 +447,8 @@ void GeodesicAlgorithmExact::propagate(const std::vector<SurfacePoint>& sources,
       geom.requireVertexGaussianCurvatures();
       bool saddle = geom.vertexGaussianCurvatures[v] < 0;
       geom.unrequireVertexGaussianCurvatures();
-      return saddle || v.isBoundary();
+      return saddle || vertexIsBoundary[v];
+      // return saddle;
     };
 
     bool const turn_left = saddleOrBoundary(he.tailVertex());

--- a/src/surface/exact_geodesics.cpp
+++ b/src/surface/exact_geodesics.cpp
@@ -440,7 +440,6 @@ void GeodesicAlgorithmExact::propagate(const std::vector<SurfacePoint>& sources,
     // bool const last_interval = min_interval->stop() == edge->length();
     bool const last_interval = min_interval->next() == nullptr;
 
-    // just in case, always propagate boundary edges
     auto saddleOrBoundary = [&](Vertex v) -> bool {
       geom.requireVertexGaussianCurvatures();
       bool saddle = geom.vertexGaussianCurvatures[v] < 0;
@@ -486,6 +485,13 @@ void GeodesicAlgorithmExact::propagate(const std::vector<SurfacePoint>& sources,
     }
 
     for (Halfedge neighboring_halfedge : edge.adjacentHalfedges()) {
+
+      //== Check some early exit conditions
+      if (!neighboring_halfedge.isInterior()) continue;
+
+      // just in case, always propagate boundary edges
+      if (!edge.isBoundary() && min_interval->halfedge() == neighboring_halfedge) continue;
+
       Face face = neighboring_halfedge.face();
 
       // if we come from 1, go to 2

--- a/src/surface/surface_mesh.cpp
+++ b/src/surface/surface_mesh.cpp
@@ -431,6 +431,14 @@ EdgeData<bool> SurfaceMesh::getEdgeOrientedStatus() {
   return edgeIsOriented;
 }
 
+VertexData<bool> SurfaceMesh::getVertexBoundaryStatus() {
+  VertexData<bool> vertexIsBoundary(*this);
+  for (Vertex v : vertices()) {
+    vertexIsBoundary[v] = v.isBoundary();
+  }
+  return vertexIsBoundary;
+}
+
 size_t SurfaceMesh::nConnectedComponents() {
   VertexData<size_t> vertInd = getVertexIndices();
   DisjointSets dj(nVertices());


### PR DESCRIPTION
This should fix issue #119 about running MMP on meshes with boundary. 

There was a bug in the MMP implementation (a line I accidentally deleted while porting the code over) which only caused problems on `ManifoldSurfaceMesh`es with boundary, as well as a bug in the `Vertex::isBoundary()` check on nonmanifold meshes.