### PR TITLE
Crouzeix raviart Laplacians and mass matrix

### DIFF
--- a/docs/docs/surface/geometry/quantities.md
+++ b/docs/docs/surface/geometry/quantities.md
@@ -477,9 +477,9 @@ All operators are indexed over mesh elements according to the natural iteration 
 
 ??? func "Crouzeix-Raviart Laplacian"
     
-    ##### Crouzeix-Raviart laplacian
+    ##### Crouzeix-Raviart Laplacian
 
-    The discrete Laplace operator, discretized via the piecewise linear *Crouzeix-Raviart* elements on edges.
+    The discrete Laplace operator, discretized via the piecewise linear *Crouzeix-Raviart* basis functions associated with edge midpoints.
 
     A $|E| \times |E|$ real matrix. Always symmetric and positive semi-definite. This is the _weak_ Laplace operator, if we use it to evaluate $\mathsf{y} \leftarrow \mathsf{L} \mathsf{x}$, $\mathsf{x}$ should hold _pointwise_ quantities at edge midpoints, and the result $\mathsf{y}$ will contain _integrated_ values of the result in the neighborhood of each edge midpoint. If used to solve a Poisson problem, a mass matrix is likely necessary on the right hand side.
 
@@ -494,7 +494,7 @@ All operators are indexed over mesh elements according to the natural iteration 
 
     A mass matrix at edges, where the edge area is $1/3$ the incident face areas.
 
-    A $|E| \times |E|$ real diagonal matrix. Corresponds to the Galerkin mass matrix for Crouzeix-Raviart elements, but is already diagonal without lumping.
+    A $|E| \times |E|$ real diagonal matrix. Corresponds to the Galerkin mass matrix for Crouzeix-Raviart elements, which is already diagonal without lumping.
 
     Only valid on triangular meshes.
 
@@ -507,9 +507,9 @@ All operators are indexed over mesh elements according to the natural iteration 
 
     A discrete connection Laplacian operator, which applies to vector fields defined in edge tangent spaces
 
-    A $|E| \times |E|$ complex matrix. Always Hermitian.
+    A $|E| \times |E|$ complex matrix. Always Hermitian and positive semi-definite.
 
-    Given a complex vector $\mathsf{x}$ of tangent vectors at edge midpoints, apply the operator by multiplying $\mathsf{L} * \mathsf{x}$.
+    Given a complex vector $\mathsf{x}$ of tangent vectors at edge midpoints, apply the operator by multiplying $\mathsf{L} * \mathsf{x}$. Like other mesh elements, the $x$-axis of the tangent space at edge `e` points in the direction of `e.halfedge()`.
 
     Only valid on triangular meshes.
 

--- a/docs/docs/surface/geometry/quantities.md
+++ b/docs/docs/surface/geometry/quantities.md
@@ -475,6 +475,48 @@ All operators are indexed over mesh elements according to the natural iteration 
     - **member:** `Eigen::SparseMatrix<std::complex<double>> IntrinsicGeometryInterface::vertexConnectionLaplacian`
     - **require:** `void IntrinsicGeometryInterface::requireVertexConnectionLaplacian()`
 
+??? func "Crouzeix-Raviart Laplacian"
+    
+    ##### Crouzeix-Raviart laplacian
+
+    The discrete Laplace operator, discretized via the piecewise linear *Crouzeix-Raviart* elements on edges.
+
+    A $|E| \times |E|$ real matrix. Always symmetric and positive semi-definite. This is the _weak_ Laplace operator, if we use it to evaluate $\mathsf{y} \leftarrow \mathsf{L} \mathsf{x}$, $\mathsf{x}$ should hold _pointwise_ quantities at edge midpoints, and the result $\mathsf{y}$ will contain _integrated_ values of the result in the neighborhood of each edge midpoint. If used to solve a Poisson problem, a mass matrix is likely necessary on the right hand side.
+
+    Only valid on triangular meshes.
+
+    - **member:** `Eigen::SparseMatrix<double> IntrinsicGeometryInterface::crouzeixRaviartLaplacian`
+    - **require:** `void IntrinsicGeometryInterface::requireCrouzeixRaviartLaplacian()`
+
+??? func "Crouzeix-Raviart mass matrix"
+
+    ##### Crouzeix-Raviart mass matrix
+
+    A mass matrix at edges, where the edge area is $1/3$ the incident face areas.
+
+    A $|E| \times |E|$ real diagonal matrix. Corresponds to the Galerkin mass matrix for Crouzeix-Raviart elements, but is already diagonal without lumping.
+
+    Only valid on triangular meshes.
+
+    - **member:** `Eigen::SparseMatrix<double> IntrinsicGeometryInterface::crouzeixRaviartMassMatrix`
+    - **require:** `void IntrinsicGeometryInterface::requireCrouzeixRaviartMassMatrix()`
+
+??? func "Crouzeix-Raviart connection Laplacian"
+
+    ##### Crouzeix-Raviart connection Laplacian
+
+    A discrete connection Laplacian operator, which applies to vector fields defined in edge tangent spaces
+
+    A $|E| \times |E|$ complex matrix. Always Hermitian.
+
+    Given a complex vector $\mathsf{x}$ of tangent vectors at edge midpoints, apply the operator by multiplying $\mathsf{L} * \mathsf{x}$.
+
+    Only valid on triangular meshes.
+
+    - **member:** `Eigen::SparseMatrix<double> IntrinsicGeometryInterface::crouzeixRaviartConnectionLaplacian`
+    - **require:** `void IntrinsicGeometryInterface::requireCrouzeixRaviartConnectionLaplacian()`
+
+
 ??? func "DEC operators"
 
     ##### DEC operators

--- a/include/geometrycentral/surface/intrinsic_geometry_interface.h
+++ b/include/geometrycentral/surface/intrinsic_geometry_interface.h
@@ -74,14 +74,14 @@ public:
   EdgeData<double> edgeCotanWeights;
   void requireEdgeCotanWeights();
   void unrequireEdgeCotanWeights();
- 
-  // Shape length scale 
+
+  // Shape length scale
   // (computed as sqrt(total_area), so it is a property of the shape, not the mesh)
   double shapeLengthScale = -1;
   void requireShapeLengthScale();
   void unrequireShapeLengthScale();
-  
-  // Mesh length scale 
+
+  // Mesh length scale
   // (computed as mean edge length, so it is a property of the mesh moreso than the shape)
   double meshLengthScale = -1;
   void requireMeshLengthScale();
@@ -143,6 +143,25 @@ public:
   void requireFaceConnectionLaplacian();
   void unrequireFaceConnectionLaplacian();
 
+  // I thought about calling the Crouzeix-Raviart matrices <edgeMidpointLaplacian>, <edgeMidpointGalerkinMassMatrix>,
+  // etc. because they are formed via integration of piecewise linear elements associated with edge midpoints. But these
+  // elements are more commonly referred to via Crouzeix-Raviart in the literature.
+
+  // Crouzeix-Raviart Laplace matrix
+  Eigen::SparseMatrix<double> crouzeixRaviartLaplacian;
+  void requireCrouzeixRaviartLaplacian();
+  void unrequireCrouzeixRaviartLaplacian();
+
+  // Crouzeix-Raviart mass matrix
+  Eigen::SparseMatrix<double> crouzeixRaviartMassMatrix;
+  void requireCrouzeixRaviartMassMatrix();
+  void unrequireCrouzeixRaviartMassMatrix();
+
+  // Crouzeix-Raviart connection Laplacian. Corresponds to the complex version, not the 2E x 2E version.
+  Eigen::SparseMatrix<double> crouzeixRaviartConnectionLaplacian;
+  void requireCrouzeixRaviartConnectionLaplacian();
+  void unrequireCrouzeixRaviartConnectionLaplacian();
+
   // DEC Operators
   Eigen::SparseMatrix<double> hodge0, hodge0Inverse, hodge1, hodge1Inverse, hodge2, hodge2Inverse, d0, d1;
   void requireDECOperators();
@@ -192,12 +211,12 @@ protected:
   // Edge cotan weight
   DependentQuantityD<EdgeData<double>> edgeCotanWeightsQ;
   virtual void computeEdgeCotanWeights();
-  
-  // Shape length scale 
+
+  // Shape length scale
   DependentQuantityD<double> shapeLengthScaleQ;
   virtual void computeShapeLengthScale();
-  
-  // Mesh length scale 
+
+  // Mesh length scale
   DependentQuantityD<double> meshLengthScaleQ;
   virtual void computeMeshLengthScale();
 
@@ -246,6 +265,18 @@ protected:
   // Face connection Laplacian
   DependentQuantityD<Eigen::SparseMatrix<std::complex<double>>> faceConnectionLaplacianQ;
   virtual void computeFaceConnectionLaplacian();
+
+  // Crouzeix-Raviart Laplacian
+  DependentQuantityD<Eigen::SparseMatrix<double>> crouzeixRaviartLaplacianQ;
+  virtual void computeCrouzeixRaviartLaplacian();
+
+  // Crouzeix-Raviart mass matrix
+  DependentQuantityD<Eigen::SparseMatrix<double>> crouzeixRaviartMassMatrixQ;
+  virtual void computeCrouzeixRaviartMassMatrix();
+
+  // Crouzeix-Raviart connection Laplacian
+  DependentQuantityD<Eigen::SparseMatrix<stdd::complex<double>>> crouzeixRaviartConnectionLaplacianQ;
+  virtual void computeCrouzeixRaviartConnectionLaplacian();
 
   // DEC Operators
   // Note: The DEC operators deviate from the convention of one member per quantity. This extra array allows the

--- a/include/geometrycentral/surface/intrinsic_geometry_interface.h
+++ b/include/geometrycentral/surface/intrinsic_geometry_interface.h
@@ -158,7 +158,7 @@ public:
   void unrequireCrouzeixRaviartMassMatrix();
 
   // Crouzeix-Raviart connection Laplacian. Corresponds to the complex version, not the 2E x 2E version.
-  Eigen::SparseMatrix<double> crouzeixRaviartConnectionLaplacian;
+  Eigen::SparseMatrix<std::complex<double>> crouzeixRaviartConnectionLaplacian;
   void requireCrouzeixRaviartConnectionLaplacian();
   void unrequireCrouzeixRaviartConnectionLaplacian();
 
@@ -275,7 +275,7 @@ protected:
   virtual void computeCrouzeixRaviartMassMatrix();
 
   // Crouzeix-Raviart connection Laplacian
-  DependentQuantityD<Eigen::SparseMatrix<stdd::complex<double>>> crouzeixRaviartConnectionLaplacianQ;
+  DependentQuantityD<Eigen::SparseMatrix<std::complex<double>>> crouzeixRaviartConnectionLaplacianQ;
   virtual void computeCrouzeixRaviartConnectionLaplacian();
 
   // DEC Operators

--- a/include/geometrycentral/surface/intrinsic_geometry_interface.h
+++ b/include/geometrycentral/surface/intrinsic_geometry_interface.h
@@ -143,10 +143,6 @@ public:
   void requireFaceConnectionLaplacian();
   void unrequireFaceConnectionLaplacian();
 
-  // I thought about calling the Crouzeix-Raviart matrices <edgeMidpointLaplacian>, <edgeMidpointGalerkinMassMatrix>,
-  // etc. because they are formed via integration of piecewise linear elements associated with edge midpoints. But these
-  // elements are more commonly referred to via Crouzeix-Raviart in the literature.
-
   // Crouzeix-Raviart Laplace matrix
   Eigen::SparseMatrix<double> crouzeixRaviartLaplacian;
   void requireCrouzeixRaviartLaplacian();

--- a/include/geometrycentral/surface/mutation_manager.ipp
+++ b/include/geometrycentral/surface/mutation_manager.ipp
@@ -38,6 +38,7 @@ template <typename T>
 class SimpleSplitUpdater : public EdgeSplitPolicy {
   // General case where the pre function passes data to the post function. Both must be given.
   T data;
+
 public:
   std::function<T(Edge, double)> pre;
   std::function<void(Halfedge, Halfedge, double, T)> post;

--- a/src/surface/intrinsic_geometry_interface.cpp
+++ b/src/surface/intrinsic_geometry_interface.cpp
@@ -36,7 +36,9 @@ IntrinsicGeometryInterface::IntrinsicGeometryInterface(SurfaceMesh& mesh_) :
   vertexConnectionLaplacianQ    (&vertexConnectionLaplacian,    std::bind(&IntrinsicGeometryInterface::computeVertexConnectionLaplacian, this),     quantities),
   faceGalerkinMassMatrixQ       (&faceGalerkinMassMatrix,       std::bind(&IntrinsicGeometryInterface::computeFaceGalerkinMassMatrix, this),        quantities),
   faceConnectionLaplacianQ      (&faceConnectionLaplacian,      std::bind(&IntrinsicGeometryInterface::computeFaceConnectionLaplacian, this),       quantities),
-
+  crouzeixRaviartLaplacianQ     (&crouzeixRaviartLaplacian,     std::bind(&IntrinsicGeometryInterface::computeCrouzeixRaviartLaplacian, this),      quantities),
+  crouzeixRaviartMassMatrixQ    (&crouzeixRaviartMassMatrix,    std::bind(&IntrinsicGeometryInterface::computeCrouzeixRaviartMassMatrix, this),     quantities),
+  crouzeixRaviartConnectionLaplacianQ     (&crouzeixRaviartConnectionLaplacian,     std::bind(&IntrinsicGeometryInterface::computeCrouzeixRaviartConnectionLaplacian, this),      quantities),
 
   // DEC operators need some extra work since 8 members are grouped under one require
   DECOperatorArray{&hodge0, &hodge0Inverse, &hodge1, &hodge1Inverse, &hodge2, &hodge2Inverse, &d0, &d1},
@@ -578,6 +580,95 @@ void IntrinsicGeometryInterface::computeFaceConnectionLaplacian() {
 }
 void IntrinsicGeometryInterface::requireFaceConnectionLaplacian() { faceConnectionLaplacianQ.require(); }
 void IntrinsicGeometryInterface::unrequireFaceConnectionLaplacian() { faceConnectionLaplacianQ.unrequire(); }
+
+
+// Crouzeix-Raviart Laplacian
+void IntrinsicGeometryInterface::computeCrouzeixRaviartLaplacian() {
+  edgeIndicesQ.ensureHave();
+  halfedgeCotanWeightsQ.ensureHave();
+
+  crouzeixRaviartLaplacian = Eigen::SparseMatrix<double>(mesh.nEdges(), mesh.nEdges());
+  std::vector<Eigen::Triplet<double>> tripletList;
+
+  for (Face f : mesh.faces()) {
+    for (Halfedge he : f.adjacentHalfedges()) {
+      Halfedge heA = he.next();
+      Halfedge heB = heA.next();
+      GC_SAFETY_ASSERT(heB.next() == he, "Crouzeix-Raviart Laplacian is not yet implemented for non-triangle meshes.");
+
+      size_t iE_i = edgeIndices[heA.edge()];
+      size_t iE_j = edgeIndices[heB.edge()];
+
+      // halfedge cotan weight = (1/2) cot(theta)
+      // C-R weight = 2.0 cot(theta) (if computing the positive version)
+      double weight = 4.0 * halfedgeCotanWeights[he];
+
+      tripletList.emplace_back(iE_i, iE_j, -weight);
+      tripletList.emplace_back(iE_j, iE_i, -weight);
+      tripletList.emplace_back(iE_i, iE_i, weight);
+      tripletList.emplace_back(iE_j, iE_j, weight);
+    }
+  }
+
+  crouzeixRaviartLaplacian.setFromTriplets(tripletList.begin(), tripletList.end());
+}
+void IntrinsicGeometryInterface::requireCrouzeixRaviartLaplacian() { crouzeixRaviartLaplacianQ.require(); }
+void IntrinsicGeometryInterface::unrequireCrouzeixRaviartLaplacian() { crouzeixRaviartLaplacianQ.unrequire(); }
+
+
+// Crouzeix-Raviart mass matrix
+void IntrinsicGeometryInterface::computeCrouzeixRaviartMassMatrix() {
+  edgeIndicesQ.ensureHave();
+  faceAreasQ.ensureHave();
+
+  crouzeixRaviartMassMatrix = Eigen::SparseMatrix<double>(mesh.nEdges(), mesh.nEdges());
+  std::vector<Eigen::Triplet<double>> tripletList;
+  for (Edge e : mesh.edges()) {
+    size_t iE_i = edgeIndices[e];
+    for (Face f : e.adjacentFaces()) {
+      tripletList.emplace_back(iE_i, iE_i, faceAreas[f] / 3.0);
+    }
+  }
+  crouzeixRaviartMassMatrix.setFromTriplets(tripletList.begin(), tripletList.end());
+}
+void IntrinsicGeometryInterface::requireCrouzeixRaviartMassMatrix() { crouzeixRaviartMassMatrixQ.require(); }
+void IntrinsicGeometryInterface::unrequireCrouzeixRaviartMassMatrix() { crouzeixRaviartMassMatrixQ.unrequire(); }
+
+
+// Crouzeix-Raviart connection Laplacian (the complex version)
+void IntrinsicGeometryInterface::computeCrouzeixRaviartConnectionLaplacian() {
+  edgeIndicesQ.ensureHave();
+  halfedgeCotanWeightsQ.ensureHave();
+  cornerAnglesQ.ensureHave();
+
+  crouzeixRaviartConnectionLaplacian = Eigen::SparseMatrix<std::complex<double>>(mesh.nEdges(), mesh.nEdges());
+  std::vector<Eigen::Triplet<double>> tripletList;
+  for (Face f : mesh.faces()) {
+    for (Halfedge he : f.adjacentHalfedges()) {
+      Halfedge heA = he.next();
+      Halfedge heB = heA.next();
+      GC_SAFETY_ASSERT(heB.next() == he, "Crouzeix-Raviart Laplacian is not yet implemented for non-triangle meshes.");
+
+      Corner c = heB.corner(); // corner between edges A and B
+      size_t iE_i = edgeIndices[heA.edge()];
+      size_t iE_j = edgeIndices[heB.edge()];
+
+      double weight = 4.0 * halfedgeCotanWeights[he];
+      int s_ij = (heA.orientation() == heB.orientation()) ? 1 : -1;
+      std::complex<double> rot = Vector2::fromAngle(-cornerAngles[c]);
+
+      tripletList.emplace_back(iE_i, iE_i, weight);
+      tripletList.emplace_back(iE_i, iE_j, weight * rot * s_ij);
+    }
+  }
+  crouzeixRaviartConnectionLaplacian.setFromTriplets(tripletList.begin(), tripletList.end());
+}
+void IntrinsicGeometryInterface::requireCrouzeixRaviartConnectionLaplacian() {
+  crouzeixRaviartConnectionLaplacianQ.require();
+}
+void IntrinsicGeometryInterface::unrequireCrouzeixRaviartConnectionLaplacian() {
+  crouzeixRaviartConnectionLaplacianQ.unrequire();
+}
 
 
 void IntrinsicGeometryInterface::computeDECOperators() {

--- a/src/surface/intrinsic_geometry_interface.cpp
+++ b/src/surface/intrinsic_geometry_interface.cpp
@@ -642,7 +642,7 @@ void IntrinsicGeometryInterface::computeCrouzeixRaviartConnectionLaplacian() {
   cornerAnglesQ.ensureHave();
 
   crouzeixRaviartConnectionLaplacian = Eigen::SparseMatrix<std::complex<double>>(mesh.nEdges(), mesh.nEdges());
-  std::vector<Eigen::Triplet<double>> tripletList;
+  std::vector<Eigen::Triplet<std::complex<double>>> tripletList;
   for (Face f : mesh.faces()) {
     for (Halfedge he : f.adjacentHalfedges()) {
       Halfedge heA = he.next();
@@ -654,11 +654,14 @@ void IntrinsicGeometryInterface::computeCrouzeixRaviartConnectionLaplacian() {
       size_t iE_j = edgeIndices[heB.edge()];
 
       double weight = 4.0 * halfedgeCotanWeights[he];
-      int s_ij = (heA.orientation() == heB.orientation()) ? 1 : -1;
-      std::complex<double> rot = Vector2::fromAngle(-cornerAngles[c]);
+      double s_ij = (heA.orientation() == heB.orientation()) ? 1. : -1.;
+      std::complex<double> rot_ij = -Vector2::fromAngle(-cornerAngles[c]);
+      std::complex<double> rot_ji = -Vector2::fromAngle(cornerAngles[c]);
 
       tripletList.emplace_back(iE_i, iE_i, weight);
-      tripletList.emplace_back(iE_i, iE_j, weight * rot * s_ij);
+      tripletList.emplace_back(iE_j, iE_j, weight);
+      tripletList.emplace_back(iE_i, iE_j, -weight * rot_ij * s_ij);
+      tripletList.emplace_back(iE_j, iE_i, -weight * rot_ji * s_ij);
     }
   }
   crouzeixRaviartConnectionLaplacian.setFromTriplets(tripletList.begin(), tripletList.end());


### PR DESCRIPTION
I've added three functions in `intrinsic_geometry_interface.cpp`, implementing a `crouzeixRaviartLaplacian`, `crouzeixRaviartMassMatrix`, and `crouzeixRaviartConnectionLaplacian`. These operators/matrix are analogous to the vertex-based cotan Laplacian and Galerkin mass matrix, but discretized using the _Crouzeix-Raviart_ (C-R) basis functions instead. The C-R basis elements are essentially Lagrange elements but based at edge midpoints: They are piecewise linear, have a value at 1 at its associated edge midpoint, and is 0 at all other adjacent edge midpoints.

In graphics/geometry processing, C-R elements have been used, for example, to [discretize bending energies](https://cims.nyu.edu/gcl/papers/wardetzky2007dqb.pdf), do [Hodge decomposition](http://www.polthier.info/articles/hodge/hodge_final.pdf), and [discretize vector Dirichlet energy](https://odedstein.com/projects/a-simple-discretization/a-simple-discretization.pdf). They can also be useful vs. the vertex Laplacians in the sense of having more DOFs, because there are typically more edges than vertices in a mesh, and there are only two faces in the support of each C-R basis function. I've used the C-R Laplacian for a couple projects now, so I figured it would be useful to add to geometry-central :)

The C-R connection Laplacian is implemented using complex numbers, in the same vein as `vertexConnectionLaplacian`.

I coded up a [demo project](https://github.com/nzfeng/crouzeix-raviart-demo) to demonstrate the C-R Laplacians in action: The first picture solves a (scalar) Poisson problem diffusing some point sources, the latter two pictures show two views of the same bunny mesh after applying the Vector Heat Method to parallel-transport an initial vector, shown in magenta. I didn't have a good method on hand for displaying vectors in edge tangent spaces, so the vector field visualization is kind of hacked up: adding a `SurfaceMesh::addEdgeIntrinsicVectorQuantity()` function to Polyscope is on my to-do list!

This implementation assumes a triangle mesh; no quad Crouzeix-Raviart yet :)

![poisson-problem](https://user-images.githubusercontent.com/27327961/190477709-6509f42d-7ff7-47c4-951b-6bbc38476ad0.png)

![parallel-transport_front](https://user-images.githubusercontent.com/27327961/190477713-2befdc17-4cfc-4342-afc3-ecd1f8091601.png)
![parallel-transport_back](https://user-images.githubusercontent.com/27327961/190477718-9f797278-04ab-48df-b895-231503e440f7.png)
