### PR TITLE
Fix MMP path extraction bug

### DIFF
--- a/docs/docs/surface/algorithms/geodesic_paths.md
+++ b/docs/docs/surface/algorithms/geodesic_paths.md
@@ -56,6 +56,7 @@ The result is returned as a `TraceGeodesicResult`, which has 5 fields:
 | `#!cpp Vector2 endingDir`| the incoming direction to the final point, in its tangent space |
 | `#!cpp bool hitBoundary`| did the path stop early because we hit a boundary? |
 | `#!cpp bool hasPath`| is `pathPoints` populated? |
+| `#!cpp double length`| length of the traced path (generally equals norm of `traceVec` unless tracing stopped early due to hitting a boundary/barrier edge or due to the iteration limit `maxIters`) |
 
 
 ## Tangent Spaces

--- a/include/geometrycentral/surface/trace_geodesic.h
+++ b/include/geometrycentral/surface/trace_geodesic.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "geometrycentral/surface/manifold_surface_mesh.h"
 #include "geometrycentral/surface/intrinsic_geometry_interface.h"
+#include "geometrycentral/surface/manifold_surface_mesh.h"
 #include "geometrycentral/surface/surface_point.h"
 
 
@@ -15,6 +15,8 @@ struct TraceGeodesicResult {
   Vector2 endingDir;                    // the incoming direction to the final point, in its tangent space
   bool hitBoundary = false;             // did the trace stop early because we hit a boundary?
   bool hasPath = false;                 // is pathPoints populated?
+  double length;                        // length of traced path (generally equals norm of traceVec,
+                                        // unless tracing stopped early)
 };
 
 struct TraceOptions {

--- a/src/surface/exact_geodesics.cpp
+++ b/src/surface/exact_geodesics.cpp
@@ -120,6 +120,7 @@ void GeodesicAlgorithmExact::possible_traceback_edges(const SurfacePoint& point,
   case SurfacePointType::Vertex: {
     Vertex v = point.vertex;
     for (Halfedge he : v.outgoingHalfedges()) {
+      if (he.face().isBoundaryLoop()) continue; // don't try to trace along virtual boundary face
       storage.push_back(he.next().edge());
     }
     break;


### PR DESCRIPTION
Fix #133. There was a minor logic error in path extraction around manifold mesh boundaries. I sometimes tried to trace back along the virtual boundary loop faces that `ManifoldSurfaceMesh` uses, which caused some errors. Adding the `isBoundaryLoop` check to line 123 of `exact_geodesics.cpp` fixes the bug.

Also modifies `TraceGeodesicResult` to return the length of the traced path.