### PR TITLE
Optimize barycentric coordinate computation

### DIFF
--- a/include/geometrycentral/surface/barycentric_coordinate_helpers.h
+++ b/include/geometrycentral/surface/barycentric_coordinate_helpers.h
@@ -23,7 +23,6 @@ double displacementLength2(Vector3 displacement, Vector3 triangleLengths);
 double displacementLength(Vector3 displacement, Vector3 triangleLengths);
 
 // Convert between cartesian and barycentric coordinates
-Vector3 cartesianVectorToBarycentric(const std::array<Vector2, 3>& vertCoords, Vector2 faceVec);
 Vector2 barycentricDisplacementToCartesian(const std::array<Vector2, 3>& vertCoords, Vector3 baryVec);
 
 // Normalize to sum to 1 (does nothing else)

--- a/include/geometrycentral/surface/barycentric_coordinate_helpers.ipp
+++ b/include/geometrycentral/surface/barycentric_coordinate_helpers.ipp
@@ -25,26 +25,6 @@ inline Vector2 barycentricDisplacementToCartesian(const std::array<Vector2, 3>& 
   return vertCoords[0] * baryVec.x + vertCoords[1] * baryVec.y + vertCoords[2] * baryVec.z;
 }
 
-inline Vector3 cartesianVectorToBarycentric(const std::array<Vector2, 3>& vertCoords, Vector2 faceVec, bool verbose) {
-
-
-  // Build matrix for linear transform problem
-  // (last constraint comes from chosing the displacement vector with sum = 0)
-  Eigen::Matrix3d A;
-  Eigen::Vector3d rhs;
-  const std::array<Vector2, 3>& c = vertCoords; // short name
-  A << c[0].x, c[1].x, c[2].x, c[0].y, c[1].y, c[2].y, 1., 1., 1.;
-  rhs << faceVec.x, faceVec.y, 0.;
-
-  // Solve
-  Eigen::Vector3d result = A.colPivHouseholderQr().solve(rhs);
-  Vector3 resultBary{result(0), result(1), result(2)};
-
-  resultBary = normalizeBarycentricDisplacement(resultBary);
-
-  return resultBary;
-}
-
 // Allows not-normalized input
 inline Vector3 normalizeBarycentric(Vector3 baryCoords) {
   double s = sum(baryCoords);


### PR DESCRIPTION
In my application which traces thousands of geodesic paths, I found that the main bottleneck was solving the system of equations to convert cartesian -> barycentric coordinates.

I found a specialized solution for performing the conversion, and swapping it in produces the same results as the Eigen solver while doing so very much faster.

I totally understand if you're not interested in taking this change since it pulls code from a third party source and might have different behavior in case of weird things like degenerate/invalid triangles, NaNs, etc. but I thought I'd put it up to see if you're interested.