### PR TITLE
Updating the functionality of barycentric vectors

### DIFF
--- a/docs/docs/surface/utilities/barycentric_vector.md
+++ b/docs/docs/surface/utilities/barycentric_vector.md
@@ -54,11 +54,11 @@ Barycentric vectors support addition, subtraction, scalar multiplication, and sc
 
     Returns the squared norm of the vector. Because the norm depends on the geometry, you must pass in the geometry (either intrinsic or extrinsic) on which the vector is defined.
 
-??? func "`#!cpp BarycentricVector BarycentricVector::rotated90(IntrinsicGeometryInterface& geom) const`"
+??? func "`#!cpp BarycentricVector BarycentricVector::rotate90(IntrinsicGeometryInterface& geom) const`"
 
     Rotate the given tangent vector 90 degrees counter-clockwise within the face it belongs to. This function requires the geometry, since the meaning of "90 degrees" depends on the geometry of the triangle. If the vector is initially an edge-type vector, this function will return a face-type vector whose face is the one the rotated vector "points into"; though if the edge is a boundary edge, the returned vector will always lie within an interior face.
 
-??? func "`#!cpp BarycentricVector BarycentricVector::rotated(IntrinsicGeometryInterface& geom, double angle) const`"
+??? func "`#!cpp BarycentricVector BarycentricVector::rotate(IntrinsicGeometryInterface& geom, double angle) const`"
 
     Rotate the given tangent vector counter-clockwise within the face it belongs to, by the given angle (specified in radians). This function requires the geometry, since the rotation depends on the geometry of the triangle. If the vector is initially an edge-type vector, this function will return a face-type vector whose face is the one the rotated vector "points into"; though if the edge is a boundary edge, the returned vector will always lie within an interior face.
 

--- a/docs/docs/surface/utilities/barycentric_vector.md
+++ b/docs/docs/surface/utilities/barycentric_vector.md
@@ -2,7 +2,7 @@ A `BarycentricVector` is a vector that lies along a surface. This vector can lie
 
 ![example of a barycentric vector within a face of an intrinsic triangulation](/media/barycentric_vector.svg)
 
-Although a barycentric vector can be constructed as the difference of two barycentric points, a barycentric vector technically does not define a single unique vector along the surface but rather a constant vector field within a face.
+Although a barycentric vector can be constructed as the difference of two barycentric points, a barycentric vector technically does not define a single unique vector along the surface but rather a constant vector field within a face --- barycentric vectors really are **vectors** (displacements), **not** rays.
 
 Using barycentric vectors, one can easily do vector arithmetic on a surface. Barycentric vectors are especially useful when working with an intrinsic representation of a surface; they can be used to do computations on vectors that depend only on intrinsic geometry, such as inner products.
 
@@ -56,7 +56,11 @@ Barycentric vectors support addition, subtraction, scalar multiplication, and sc
 
 ??? func "`#!cpp BarycentricVector BarycentricVector::rotated90(IntrinsicGeometryInterface& geom) const`"
 
-    Rotate the vector 90 degrees counter-clockwise within the face it belongs to. This requires the geometry, since the meaning of "90 degrees" depends on the geometry of the triangle.
+    Rotate the given tangent vector 90 degrees counter-clockwise within the face it belongs to. This function requires the geometry, since the meaning of "90 degrees" depends on the geometry of the triangle.
+
+??? func "`#!cpp BarycentricVector BarycentricVector::rotated(IntrinsicGeometryInterface& geom, double angle) const`"
+
+    Rotate the given tangent vector counter-clockwise within the face it belongs to, by the given angle (specified in radians). This function requires the geometry, since the rotation depends on the geometry of the triangle.
 
 Barycentric vectors also have a few utility functions:
 

--- a/docs/docs/surface/utilities/barycentric_vector.md
+++ b/docs/docs/surface/utilities/barycentric_vector.md
@@ -56,11 +56,11 @@ Barycentric vectors support addition, subtraction, scalar multiplication, and sc
 
 ??? func "`#!cpp BarycentricVector BarycentricVector::rotated90(IntrinsicGeometryInterface& geom) const`"
 
-    Rotate the given tangent vector 90 degrees counter-clockwise within the face it belongs to. This function requires the geometry, since the meaning of "90 degrees" depends on the geometry of the triangle. If the vector is initially an edge-type vector, this function will return a face-type vector whose face is the one the rotated vector "points into"; if the edge is a boundary edge, however, the returned vector will always lie within an interior face.
+    Rotate the given tangent vector 90 degrees counter-clockwise within the face it belongs to. This function requires the geometry, since the meaning of "90 degrees" depends on the geometry of the triangle. If the vector is initially an edge-type vector, this function will return a face-type vector whose face is the one the rotated vector "points into"; though if the edge is a boundary edge, the returned vector will always lie within an interior face.
 
 ??? func "`#!cpp BarycentricVector BarycentricVector::rotated(IntrinsicGeometryInterface& geom, double angle) const`"
 
-    Rotate the given tangent vector counter-clockwise within the face it belongs to, by the given angle (specified in radians). This function requires the geometry, since the rotation depends on the geometry of the triangle. If the vector is initially an edge-type vector, this function will return a face-type vector whose face is the one the rotated vector "points into"; if the edge is a boundary edge, however, the returned vector will always lie within an interior face.
+    Rotate the given tangent vector counter-clockwise within the face it belongs to, by the given angle (specified in radians). This function requires the geometry, since the rotation depends on the geometry of the triangle. If the vector is initially an edge-type vector, this function will return a face-type vector whose face is the one the rotated vector "points into"; though if the edge is a boundary edge, the returned vector will always lie within an interior face.
 
 Barycentric vectors also have a few utility functions:
 

--- a/docs/docs/surface/utilities/barycentric_vector.md
+++ b/docs/docs/surface/utilities/barycentric_vector.md
@@ -56,11 +56,11 @@ Barycentric vectors support addition, subtraction, scalar multiplication, and sc
 
 ??? func "`#!cpp BarycentricVector BarycentricVector::rotated90(IntrinsicGeometryInterface& geom) const`"
 
-    Rotate the given tangent vector 90 degrees counter-clockwise within the face it belongs to. This function requires the geometry, since the meaning of "90 degrees" depends on the geometry of the triangle.
+    Rotate the given tangent vector 90 degrees counter-clockwise within the face it belongs to. This function requires the geometry, since the meaning of "90 degrees" depends on the geometry of the triangle. If the vector is initially an edge-type vector, this function will return a face-type vector whose face is the one the rotated vector "points into".
 
 ??? func "`#!cpp BarycentricVector BarycentricVector::rotated(IntrinsicGeometryInterface& geom, double angle) const`"
 
-    Rotate the given tangent vector counter-clockwise within the face it belongs to, by the given angle (specified in radians). This function requires the geometry, since the rotation depends on the geometry of the triangle.
+    Rotate the given tangent vector counter-clockwise within the face it belongs to, by the given angle (specified in radians). This function requires the geometry, since the rotation depends on the geometry of the triangle. If the vector is initially an edge-type vector, this function will return a face-type vector whose face is the one the rotated vector "points into".
 
 Barycentric vectors also have a few utility functions:
 

--- a/docs/docs/surface/utilities/barycentric_vector.md
+++ b/docs/docs/surface/utilities/barycentric_vector.md
@@ -56,11 +56,11 @@ Barycentric vectors support addition, subtraction, scalar multiplication, and sc
 
 ??? func "`#!cpp BarycentricVector BarycentricVector::rotated90(IntrinsicGeometryInterface& geom) const`"
 
-    Rotate the given tangent vector 90 degrees counter-clockwise within the face it belongs to. This function requires the geometry, since the meaning of "90 degrees" depends on the geometry of the triangle. If the vector is initially an edge-type vector, this function will return a face-type vector whose face is the one the rotated vector "points into".
+    Rotate the given tangent vector 90 degrees counter-clockwise within the face it belongs to. This function requires the geometry, since the meaning of "90 degrees" depends on the geometry of the triangle. If the vector is initially an edge-type vector, this function will return a face-type vector whose face is the one the rotated vector "points into"; if the edge is a boundary edge, however, the returned vector will always lie within an interior face.
 
 ??? func "`#!cpp BarycentricVector BarycentricVector::rotated(IntrinsicGeometryInterface& geom, double angle) const`"
 
-    Rotate the given tangent vector counter-clockwise within the face it belongs to, by the given angle (specified in radians). This function requires the geometry, since the rotation depends on the geometry of the triangle. If the vector is initially an edge-type vector, this function will return a face-type vector whose face is the one the rotated vector "points into".
+    Rotate the given tangent vector counter-clockwise within the face it belongs to, by the given angle (specified in radians). This function requires the geometry, since the rotation depends on the geometry of the triangle. If the vector is initially an edge-type vector, this function will return a face-type vector whose face is the one the rotated vector "points into"; if the edge is a boundary edge, however, the returned vector will always lie within an interior face.
 
 Barycentric vectors also have a few utility functions:
 

--- a/include/geometrycentral/surface/barycentric_vector.h
+++ b/include/geometrycentral/surface/barycentric_vector.h
@@ -78,6 +78,9 @@ struct BarycentricVector {
   BarycentricVector rotated90(IntrinsicGeometryInterface& geom) const; // return a new vector
 };
 
+// Helper function for rotated90()
+BarycentricVector faceVectorRotated90(const BarycentricVector& v, IntrinsicGeometryInterface& geom);
+
 // Returns an arbitrary face shared by two vectors, if one exists; returns Face() if none.
 Face sharedFace(const BarycentricVector& u, const BarycentricVector& v);
 // Returns the edge shared by two vectors, if one exists; return Edge() if none.

--- a/include/geometrycentral/surface/barycentric_vector.h
+++ b/include/geometrycentral/surface/barycentric_vector.h
@@ -76,10 +76,14 @@ struct BarycentricVector {
   // Rotate the vector 90 degrees CCW within the face it belongs to.
   // This requires the geometry, since the meaning of "90 degrees" depends on the geometry of the triangle.
   BarycentricVector rotated90(IntrinsicGeometryInterface& geom) const; // return a new vector
+  // Rotate the vector the specified amount of radians CCW within the face it belongs to.
+  // This again requires the geometry.
+  BarycentricVector rotated(IntrinsicGeometryInterface& geom, double angle) const;
 };
 
-// Helper function for rotated90()
+// Helper functions for rotations
 BarycentricVector faceVectorRotated90(const BarycentricVector& v, IntrinsicGeometryInterface& geom);
+BarycentricVector faceVectorRotated(const BarycentricVector& w, IntrinsicGeometryInterface& geom, double angle);
 
 // Returns an arbitrary face shared by two vectors, if one exists; returns Face() if none.
 Face sharedFace(const BarycentricVector& u, const BarycentricVector& v);

--- a/include/geometrycentral/surface/barycentric_vector.h
+++ b/include/geometrycentral/surface/barycentric_vector.h
@@ -75,15 +75,15 @@ struct BarycentricVector {
 
   // Rotate the vector 90 degrees CCW within the face it belongs to.
   // This requires the geometry, since the meaning of "90 degrees" depends on the geometry of the triangle.
-  BarycentricVector rotated90(IntrinsicGeometryInterface& geom) const; // return a new vector
+  BarycentricVector rotate90(IntrinsicGeometryInterface& geom) const; // return a new vector
   // Rotate the vector the specified amount of radians CCW within the face it belongs to.
   // This again requires the geometry.
-  BarycentricVector rotated(IntrinsicGeometryInterface& geom, double angle) const;
+  BarycentricVector rotate(IntrinsicGeometryInterface& geom, double angle) const;
 };
 
 // Helper functions for rotations
-BarycentricVector faceVectorRotated90(const BarycentricVector& v, IntrinsicGeometryInterface& geom);
-BarycentricVector faceVectorRotated(const BarycentricVector& w, IntrinsicGeometryInterface& geom, double angle);
+BarycentricVector faceVectorRotate90(const BarycentricVector& v, IntrinsicGeometryInterface& geom);
+BarycentricVector faceVectorRotate(const BarycentricVector& w, IntrinsicGeometryInterface& geom, double angle);
 
 // Returns an arbitrary face shared by two vectors, if one exists; returns Face() if none.
 Face sharedFace(const BarycentricVector& u, const BarycentricVector& v);

--- a/include/geometrycentral/surface/barycentric_vector.ipp
+++ b/include/geometrycentral/surface/barycentric_vector.ipp
@@ -191,11 +191,11 @@ inline BarycentricVector BarycentricVector::normalizedDisplacement() const {
   return *this;
 }
 
-inline BarycentricVector BarycentricVector::rotated90(IntrinsicGeometryInterface& geom) const {
+inline BarycentricVector BarycentricVector::rotate90(IntrinsicGeometryInterface& geom) const {
 
   switch (type) {
   case BarycentricVectorType::Face: {
-    return faceVectorRotated90(*this, geom);
+    return faceVectorRotate90(*this, geom);
     break;
   }
   case BarycentricVectorType::Edge: {
@@ -205,7 +205,7 @@ inline BarycentricVector BarycentricVector::rotated90(IntrinsicGeometryInterface
       he = he.twin();
     }
     BarycentricVector w = this->inFace(he.face());
-    return faceVectorRotated90(w, geom);
+    return faceVectorRotate90(w, geom);
     break;
   }
   default:
@@ -215,11 +215,11 @@ inline BarycentricVector BarycentricVector::rotated90(IntrinsicGeometryInterface
   return *this;
 }
 
-inline BarycentricVector BarycentricVector::rotated(IntrinsicGeometryInterface& geom, double angle) const {
+inline BarycentricVector BarycentricVector::rotate(IntrinsicGeometryInterface& geom, double angle) const {
 
   switch (type) {
   case BarycentricVectorType::Face: {
-    return faceVectorRotated(*this, geom, angle);
+    return faceVectorRotate(*this, geom, angle);
     break;
   }
   case BarycentricVectorType::Edge: {
@@ -237,7 +237,7 @@ inline BarycentricVector BarycentricVector::rotated(IntrinsicGeometryInterface& 
       he = he.twin();
     }
     BarycentricVector w = this->inFace(he.face());
-    return faceVectorRotated(w, geom, angle);
+    return faceVectorRotate(w, geom, angle);
     break;
   }
   default:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ SET(SRCS
   surface/integer_coordinates_intrinsic_triangulation.cpp
   surface/common_subdivision.cpp
   surface/surface_point.cpp
+  surface/barycentric_vector.cpp
   surface/fast_marching_method.cpp
   surface/intersection.cpp
   surface/uniformize.cpp

--- a/src/surface/barycentric_vector.cpp
+++ b/src/surface/barycentric_vector.cpp
@@ -1,0 +1,28 @@
+#include "geometrycentral/surface/barycentric_vector.h"
+
+
+namespace geometrycentral {
+namespace surface {
+
+BarycentricVector faceVectorRotated90(const BarycentricVector& w, IntrinsicGeometryInterface& geom) {
+  double ui = w.faceCoords[0];
+  double uj = w.faceCoords[1];
+  double uk = w.faceCoords[2];
+  geom.requireEdgeLengths();
+  double l_ij = geom.edgeLengths[w.face.halfedge().edge()];
+  double l_jk = geom.edgeLengths[w.face.halfedge().next().edge()];
+  double l_ki = geom.edgeLengths[w.face.halfedge().next().next().edge()];
+  geom.unrequireEdgeLengths();
+  // coefficients of matrix D taking barycentric coords to 3D local coords, squared and multiplied by 2
+  double ai = l_ij * l_ij - l_jk * l_jk + l_ki * l_ki;
+  double aj = l_jk * l_jk - l_ki * l_ki + l_ij * l_ij;
+  double ak = l_ki * l_ki - l_ij * l_ij + l_jk * l_jk;
+  double s = 0.5 * (l_ij + l_jk + l_ki);
+  double A = std::sqrt(s * (s - l_ij) * (s - l_jk) * (s - l_ki));
+  Vector3 newCoords = {ak * uk - aj * uj, ai * ui - ak * uk, aj * uj - ai * ui};
+  newCoords /= (4. * A);
+  return BarycentricVector(w.face, newCoords);
+}
+
+} // namespace surface
+} // namespace geometrycentral

--- a/src/surface/barycentric_vector.cpp
+++ b/src/surface/barycentric_vector.cpp
@@ -5,6 +5,9 @@ namespace geometrycentral {
 namespace surface {
 
 BarycentricVector faceVectorRotated90(const BarycentricVector& w, IntrinsicGeometryInterface& geom) {
+  // Found via (D(fj - fi) x (fk - fi))/(2A) x (Dw), where D is the matrix taking barycentric coords to 3D local coords,
+  // where (fj - fi) x (fk - fi)/(2A) is the unit normal vector to the 3D-embedded local triangle. Then we apply D^{-1}
+  // to map back to barycentric coords.
   double ui = w.faceCoords[0];
   double uj = w.faceCoords[1];
   double uk = w.faceCoords[2];
@@ -21,6 +24,46 @@ BarycentricVector faceVectorRotated90(const BarycentricVector& w, IntrinsicGeome
   double A = std::sqrt(s * (s - l_ij) * (s - l_jk) * (s - l_ki));
   Vector3 newCoords = {ak * uk - aj * uj, ai * ui - ak * uk, aj * uj - ai * ui};
   newCoords /= (4. * A);
+  return BarycentricVector(w.face, newCoords);
+}
+
+BarycentricVector faceVectorRotated(const BarycentricVector& w, IntrinsicGeometryInterface& geom, double angle) {
+  // Found by applying the 3D axis-angle rotation matrix in 3D local coordinates (then transforming back to barycentric
+  // coordinates), which conveniently avoids (almost all) square roots.
+  double ui = w.faceCoords[0];
+  double uj = w.faceCoords[1];
+  double uk = w.faceCoords[2];
+  geom.requireEdgeLengths();
+  double l_ij = geom.edgeLengths[w.face.halfedge().edge()];
+  double l_jk = geom.edgeLengths[w.face.halfedge().next().edge()];
+  double l_ki = geom.edgeLengths[w.face.halfedge().next().next().edge()];
+  geom.unrequireEdgeLengths();
+  double lij2 = l_ij * l_ij;
+  double ljk2 = l_jk * l_jk;
+  double lki2 = l_ki * l_ki;
+  double A2 = -(l_ij - l_jk - l_ki) * (l_ij + l_jk - l_ki) * (l_ij - l_jk + l_ki) * (l_ij + l_jk + l_ki) / 16.;
+  double bA = 2. * std::sqrt(A2); // 2A
+  double qA2 = 4. * A2;           // 4A^2
+  double ai2 = 0.5 * (lij2 - ljk2 + lki2);
+  double aj2 = 0.5 * (ljk2 - lki2 + lij2);
+  double ak2 = 0.5 * (lki2 - lij2 + ljk2);
+  double cosTheta = std::cos(angle);
+  double sinTheta = std::sin(angle);
+  double oneMinusCos = 1. - cosTheta;
+  double aj2ak2 = aj2 * ak2;
+  double ai2ak2 = ai2 * ak2;
+  double ai2aj2 = ai2 * aj2;
+  double xi = (qA2 * cosTheta + oneMinusCos * aj2ak2) * ui;
+  double xj = (oneMinusCos * aj2ak2 - bA * sinTheta * aj2) * uj;
+  double xk = (oneMinusCos * aj2ak2 + bA * sinTheta * ak2) * uk;
+  double yi = (oneMinusCos * ai2ak2 + bA * sinTheta * ai2) * ui;
+  double yj = (qA2 * cosTheta + oneMinusCos * ai2ak2) * uj;
+  double yk = (oneMinusCos * ai2ak2 - bA * sinTheta * ak2) * uk;
+  double zi = (oneMinusCos * ai2aj2 - bA * sinTheta * ai2) * ui;
+  double zj = (oneMinusCos * ai2aj2 + bA * sinTheta * aj2) * uj;
+  double zk = (qA2 * cosTheta + oneMinusCos * ai2aj2) * uk;
+  Vector3 newCoords = {xi + xj + xk, yi + yj + yk, zi + zj + zk};
+  newCoords /= qA2;
   return BarycentricVector(w.face, newCoords);
 }
 

--- a/src/surface/barycentric_vector.cpp
+++ b/src/surface/barycentric_vector.cpp
@@ -4,7 +4,7 @@
 namespace geometrycentral {
 namespace surface {
 
-BarycentricVector faceVectorRotated90(const BarycentricVector& w, IntrinsicGeometryInterface& geom) {
+BarycentricVector faceVectorRotate90(const BarycentricVector& w, IntrinsicGeometryInterface& geom) {
   // Found via (D(fj - fi) x (fk - fi))/(2A) x (Dw), where D is the matrix taking barycentric coords to 3D local coords,
   // where (fj - fi) x (fk - fi)/(2A) is the unit normal vector to the 3D-embedded local triangle. Then we apply D^{-1}
   // to map back to barycentric coords.
@@ -27,7 +27,7 @@ BarycentricVector faceVectorRotated90(const BarycentricVector& w, IntrinsicGeome
   return BarycentricVector(w.face, newCoords);
 }
 
-BarycentricVector faceVectorRotated(const BarycentricVector& w, IntrinsicGeometryInterface& geom, double angle) {
+BarycentricVector faceVectorRotate(const BarycentricVector& w, IntrinsicGeometryInterface& geom, double angle) {
   // Found by applying the 3D axis-angle rotation matrix in 3D local coordinates (then transforming back to barycentric
   // coordinates), which conveniently avoids (almost all) square roots.
   double ui = w.faceCoords[0];


### PR DESCRIPTION
Nothing major -- just added additional functionality to the `BarycentricVector` object:
- `rotated90()` now supports edge-type vectors as input
- a new function `rotated()` allows rotation of vectors by arbitrary angles
- added some more detailed comments in the code so I don't forget how I derived quantities :)
- documentation updated accordingly.

Let me know if you need me to add additional test functions to geometry-central -- for these few commits, I tested everything using an external program: https://github.com/nzfeng/barycentric-vector-demo