### PR TITLE
Fix SuiteSparse call for underdetermined systems

### DIFF
--- a/src/numerical/qr_solvers.cpp
+++ b/src/numerical/qr_solvers.cpp
@@ -151,11 +151,15 @@ void Solver<T>::solve(Vector<T>& x, const Vector<T>& rhs) {
   // Solve
   // outVec = SuiteSparseQR<typename Solver<T>::SOLVER_ENTRYTYPE>(cMat, inVec, internals->context);
   // Note that the solve strategy is different for underdetermined systems
+  
+  // The types of QR solves are defined in the SuiteSparse codebase at: 
+  //      github.com/DrTimothyAldenDavis/SuiteSparse/blob/26ababc7f3af725c5fb9168a1b94850eab74b666/SPQR/Include/SuiteSparseQR_definitions.h#L42
+  // Note that the factorization is QR = AE, NOT QR = A; E is a permutation matrix 
   if (underdetermined) {
 
     // solve y = R^-T b
     cholmod_dense* y = SuiteSparseQR_solve<typename SOLVER_ENTRYTYPE<T>::type>(
-        SPQR_RTX_EQUALS_B, internals->factorization, inVec, internals->context);
+        SPQR_RTX_EQUALS_ETB, internals->factorization, inVec, internals->context);
 
     // compute x = Q*y
     outVec = SuiteSparseQR_qmult<typename SOLVER_ENTRYTYPE<T>::type>(SPQR_QX, internals->factorization, y,
@@ -169,7 +173,6 @@ void Solver<T>::solve(Vector<T>& x, const Vector<T>& rhs) {
                                                                                inVec, internals->context);
 
     // solve x = R^-1 y
-    // TODO what is this E doing here?
     outVec = SuiteSparseQR_solve<typename SOLVER_ENTRYTYPE<T>::type>(SPQR_RETX_EQUALS_B, internals->factorization, y,
                                                                      internals->context);
 


### PR DESCRIPTION
Currently, solving underdetermined systems using SuiteSparse by calling `solve` does not work. For example,

```
#include "geometrycentral/numerical/linear_solvers.h"

Eigen::Matrix<double, 2, 3> A;
A << 1, 0, 1, 0, 1, 0 ;
Vector<double> b(2);
b << 1, 2;
SparseMatrix<double> sparseA = A.sparseView();

Vector<double> sol = solve(sparseA, b);

std::cout << sol << std::endl;
```

will print out `1 1 1`, but the correct answer is `0.5 2 0.5`. This is because SuiteSparse's QR decomposition includes a permutation matrix (i.e., `E` such that `QR=AE`), but geometry central does not properly account for this in the call to `SuiteSparseQR_solve`. (Thank you @MarkGillespie for helping to find the bug!)