### PR TITLE
Working towards running BGL algorithms on ManifoldSurfaceMesh

### DIFF
--- a/include/geometrycentral/utilities/element_iterators.h
+++ b/include/geometrycentral/utilities/element_iterators.h
@@ -34,6 +34,8 @@ public:
   RangeIteratorBase() = default;
   RangeIteratorBase(typename F::ParentMeshT* mesh_, size_t iStart_, size_t iEnd_);
   const RangeIteratorBase& operator++();
+  RangeIteratorBase operator++(int);
+
   bool operator==(const RangeIteratorBase& other) const;
   bool operator!=(const RangeIteratorBase& other) const;
   typename F::Etype operator*() const;

--- a/include/geometrycentral/utilities/element_iterators.h
+++ b/include/geometrycentral/utilities/element_iterators.h
@@ -31,6 +31,7 @@ template <typename F>
 class RangeIteratorBase {
 
 public:
+  RangeIteratorBase() = default;
   RangeIteratorBase(typename F::ParentMeshT* mesh_, size_t iStart_, size_t iEnd_);
   const RangeIteratorBase& operator++();
   bool operator==(const RangeIteratorBase& other) const;

--- a/include/geometrycentral/utilities/element_iterators.ipp
+++ b/include/geometrycentral/utilities/element_iterators.ipp
@@ -22,6 +22,13 @@ inline const RangeIteratorBase<F>& RangeIteratorBase<F>::operator++() {
 }
 
 template <typename F>
+inline RangeIteratorBase<F> RangeIteratorBase<F>::operator++(int) {
+  RangeIteratorBase<F> tmp = *this;
+  ++(*this);
+  return tmp;
+}
+
+template <typename F>
 inline bool RangeIteratorBase<F>::operator==(const RangeIteratorBase<F>& other) const {
   return iCurr == other.iCurr;
 }

--- a/include/geometrycentral/utilities/mesh_data.h
+++ b/include/geometrycentral/utilities/mesh_data.h
@@ -25,6 +25,10 @@ public:
   // improve vectorization and performance.
   using DATA_T = Eigen::Matrix<T, Eigen::Dynamic, 1>;
 
+  // Types to make it more similar to std::map
+  using key_type    = E;
+  using mapped_type = T;
+  using value_type  = std::pair<key_type,mapped_type>;
 protected:
   // The mesh that this data is defined on
   using ParentMeshT = typename E::ParentMeshT;


### PR DESCRIPTION
Hello,
As a mesh is a graph with vertices and edges it is sometimes useful to run graph algorithms on a mesh.
This PR is the first step towards this goal which will enable to write code like

```cpp

  geometrycentral::surface::VertexData<double> distance(*mesh);

  auto source = *(vertices(*mesh).first);
  boost::breadth_first_search(*mesh, source,
    boost::visitor(boost::make_bfs_visitor(boost::record_distances(boost::make_assoc_property_map(distance), boost::on_tree_edge())))
    .vertex_index_map(boost::associative_property_map<geometrycentral::surface::VertexData<std::size_t>>(mesh->getVertexIndices())));

  for(auto v : mesh->vertices()){
    std::cout << v << " at distance " << distance[v] << std::endl;
  }
```