### PR TITLE
Move O(n) operations to the initializer in exact_geodesics

### DIFF
--- a/include/geometrycentral/surface/exact_geodesics.h
+++ b/include/geometrycentral/surface/exact_geodesics.h
@@ -100,6 +100,7 @@ protected:
   bool check_stop_conditions(unsigned& index) const;
 
   void clear();
+  void clear_data();
 
   list_pointer interval_list(Edge e) { return &m_edge_interval_lists[e]; };
   const_list_pointer interval_list(Edge e) const { return &m_edge_interval_lists[e]; };

--- a/src/surface/exact_geodesics.cpp
+++ b/src/surface/exact_geodesics.cpp
@@ -446,18 +446,7 @@ void GeodesicAlgorithmExact::propagate(const std::vector<SurfacePoint>& sources,
 
   IntervalWithStop candidates[2];
 
-  int itr = 0;
-  auto _start = std::chrono::high_resolution_clock::now();
-  auto _before = _start;
-
   while (!m_queue.empty()) {
-    itr++;
-
-    auto _now = std::chrono::high_resolution_clock::now();
-    // std::cout << "  " << itr << ": " << std::chrono::duration_cast<std::chrono::microseconds>(_now - _before).count() << "us" << std::endl;
-
-    _before = _now;
-
     m_queue_max_size = std::max(m_queue.size(), m_queue_max_size);
 
     unsigned const check_period = 10;


### PR DESCRIPTION
Fixed `exact_geodesics` so that you do not need to run O(n) operations whenever you query the geodesic path.
This is especially useful when you have a fixed mesh/geometry and want to query the geodesic path multiple times.

## Summary of contribution

- Moved `geom.requireCornerAngles()` and `geom.requireVertexGaussianCurvatures()` to the initializer
- Added `clear_data()` that clears the data except the ones associated with the mesh/geometry

## Usage

```c++
std::vector<SurfacePoint> p0s, p1s;
// initialize your p0s/p1s here

GeodesicAlgorithmExact mmp(mesh, geometry);

for (int i = 0; i < p0s.size(); i++) {
  auto p0 = p0s[i];
  auto p1 = p1s[i];

  mmp.propagate({p0}, GEODESIC_INF, {p1});
  std::vector<SurfacePoint> path = mmp.traceBack(p1);
  // do science with your path here

  // clear the propagated data so that you can use `mmp` for another geodesic computation
  mmp.clear_data();
}
```