### PR TITLE
fix cmake version issue

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 
-cmake_policy(SET CMP0169 OLD)   # use deprecated FetchContent_Populate
+if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD) # use deprecated FetchContent_Populate
+endif()
 
 # We will accumulate all depenency includes and link libraries here
 # (can be relative paths when building list, we will convert all to absolute at end)


### PR DESCRIPTION
Currently, `deps/CMakeLists.txt` requires CMAKE version 3.30 due to the line `cmake_policy(SET CMP0169 OLD)`. This policy fixes a deprecation added in 3.30, so it is only needed in versions greater than or equal to 3.30. The fix here causes the cmake_policy command to only be called in this case, thus restoring functionality in previous cmake versions. 

This builds on my machine with cmake version 3.31.2.