### PR TITLE
add cmake exported targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.14.0)
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
 
 project(geometry-central)
+set(PROJECT_VERSION 0.1.0)
 
 ### Policy settings
 cmake_policy(SET CMP0054 NEW)   # don't implicitly dereference inside if()
@@ -51,15 +54,16 @@ SET(GC_HAVE_SUITESPARSE ${GC_HAVE_SUITESPARSE} PARENT_SCOPE)
 add_subdirectory(src)
 
 # install
-install(
-  TARGETS geometry-central
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib)
 
+configure_package_config_file(geometry-central-config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/geometry-central-config.cmake INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/geometry-central/cmake)
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/geometry-centralConfigVersion.cmake COMPATIBILITY SameMajorVersion)
+install(TARGETS geometry-central eigen nanort nanoflann happly EXPORT geometry-central-targets ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(EXPORT geometry-central-targets FILE geometry-centralTargets.cmake DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/geometry-central/cmake)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/geometry-central-config.cmake DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/geometry-central/cmake)
 install(
   DIRECTORY ${CMAKE_SOURCE_DIR}/include/
-  DESTINATION include
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   FILES_MATCHING
   PATTERN "*.h"
   PATTERN "*.ipp")

--- a/geometry-central-config.cmake.in
+++ b/geometry-central-config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+get_filename_component(LIST_DIR ${CMAKE_CURRENT_LIST_FILE} PATH)
+include(${LIST_DIR}/@PROJECT_NAME@Targets.cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -175,7 +175,10 @@ SET(HEADERS
 add_library(geometry-central ${SRCS} ${HEADERS})
 
 # Includes from this project
-target_include_directories(geometry-central PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+target_include_directories(geometry-central PUBLIC
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+)
 
 # Add all includes and link libraries from dependencies, which were populated in deps/CMakeLists.txt
 target_link_libraries(geometry-central PUBLIC ${GC_DEP_LIBS})


### PR DESCRIPTION
Add exported targets to make it easier to link against geometry-central.

Projects can then simply use
```cmake
find_package(geometry-central)
```
to link against it and configure the location using `geometry-central_DIR`, which will also be automatically detected if geometry-central is installed in `$CMAKE_PREFIX_PATH`.
I also added the version (from the latest tag) to the CMakeLists.txt so that projects can require a specific version.

The targets should probably be handled by `${GC_DEP_LIBS}`, but that causes a mismatch between the `eigen` and `Eigen3::Eigen` targets, and I do not want to change too much in your CMakeFiles.txt files. Possibly these dependencies could also be private in case that geometry-central links them statically.