### PR TITLE
Compatibility with recent nanoflann versions.

### DIFF
--- a/src/utilities/knn.cpp
+++ b/src/utilities/knn.cpp
@@ -25,7 +25,7 @@ struct Vector3Adaptor {
 class NearestNeighborFinder::KNNImpl {
 public:
   // == Types
-  typedef nanoflann::KDTreeSingleIndexAdaptor<nanoflann::L2_Simple_Adaptor<double, Vector3Adaptor>, Vector3Adaptor, 3>
+  typedef nanoflann::KDTreeSingleIndexAdaptor<nanoflann::L2_Simple_Adaptor<double, Vector3Adaptor>, Vector3Adaptor, 3, size_t>
       KD_Tree_T;
 
   // == Constructors
@@ -80,8 +80,12 @@ public:
     // nanoflann wants a SQUARED raidus
     double radSq = rad * rad;
 
+#if NANOFLANN_VERSION >= 0x150
+    std::vector<nanoflann::ResultItem<size_t, double>> outPairs;
+#else
     std::vector<std::pair<size_t, double>> outPairs;
-    tree.radiusSearch(&query[0], radSq, outPairs, nanoflann::SearchParams());
+#endif
+    tree.radiusSearch(&query[0], radSq, outPairs, {});
 
     // copy in to an array off indices
     std::vector<size_t> outInds(outPairs.size());


### PR DESCRIPTION
- v1.5.0: Changed output arg from `std::pair<>` to `nanoflann::ResultItem<>`
- v1.5.0: `naonflann::SearchParams` renamed to `naonflann::SearchParameters` (because the first arg in the constructor was also removed from the API).
- v1.4.0: default template arg for `IndexType/AccessorType` was changed from `size_t` to `uint32_t`:
  https://github.com/jlblancoc/nanoflann/pull/154

I haven't updated the nanoflann version bundled with geometry-central, but I've confirmed that it compiles locally with the latest version.