### PR TITLE
Update nanort version and include path.

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -79,7 +79,7 @@ else()
       FetchContent_GetProperties(eigen)
       if(NOT eigen_POPULATED)
           FetchContent_Populate(eigen) # NOTE: this form was deprecated in 3.30, we set CMP0169 to silence the warning
-          
+
           include(EigenChecker)
           eigen3checker(${eigen_SOURCE_DIR} 3.3)
       endif()
@@ -151,6 +151,13 @@ endif()
 if (NOT TARGET nanort)
     add_library(nanort INTERFACE)
     target_include_directories(nanort INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/nanort/include>)
+
+    # For backward compatibility, we need to make a symlink in the build directory.
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/nanort)
+    file(CREATE_LINK
+        ${CMAKE_CURRENT_SOURCE_DIR}/nanort/include/nanort.h
+        ${CMAKE_CURRENT_BINARY_DIR}/include/nanort/nanort.h SYMBOLIC)
+    target_include_directories(nanort INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
 endif()
 
 if (NOT TARGET nanoflann)

--- a/include/geometrycentral/surface/mesh_ray_tracer.h
+++ b/include/geometrycentral/surface/mesh_ray_tracer.h
@@ -3,7 +3,7 @@
 #include "geometrycentral/surface/geometry.h"
 
 
-#include "nanort/nanort.h"
+#include "nanort.h"
 
 namespace geometrycentral {
 namespace surface {
@@ -34,9 +34,7 @@ private:
   // Data for the BVH
   std::vector<double> rawPositions;
   std::vector<unsigned int> rawFaces;
-  nanort::BVHAccel<double, nanort::TriangleMesh<double>, nanort::TriangleSAHPred<double>,
-                   nanort::TriangleIntersector<double>>
-      accel;
+  nanort::BVHAccel<double> accel;
 
   double tFar;
 };

--- a/src/surface/simple_polygon_mesh.cpp
+++ b/src/surface/simple_polygon_mesh.cpp
@@ -1,7 +1,7 @@
 #include "geometrycentral/surface/simple_polygon_mesh.h"
 
 #include "happly.h"
-#include "nanort/nanort.h"
+#include "nanort.h"
 
 #include <algorithm>
 #include <deque>
@@ -656,9 +656,7 @@ void SimplePolygonMesh::consistentlyOrientFaces(bool outwardOrient) {
   int32_t N_RAYS_PER_FACE = 4;
   std::vector<double> rawPositions;
   std::vector<unsigned int> rawFaces;
-  nanort::BVHAccel<double, nanort::TriangleMesh<double>, nanort::TriangleSAHPred<double>,
-                   nanort::TriangleIntersector<double>>
-      accel;
+  nanort::BVHAccel<double> accel;
   double lengthScale = -1;
   auto traceDist = [&](Vector3 root, Vector3 dir) {
     nanort::Ray<double> ray;
@@ -667,9 +665,10 @@ void SimplePolygonMesh::consistentlyOrientFaces(bool outwardOrient) {
     for (int i = 0; i < 3; i++) ray.org[i] = root[i];
     for (int i = 0; i < 3; i++) ray.dir[i] = dir[i];
     nanort::BVHTraceOptions trace_options;
+    nanort::TriangleIntersection<double> isect;
     nanort::TriangleIntersector<double> triangle_intersector(rawPositions.data(), rawFaces.data(), sizeof(double) * 3);
-    bool hit = accel.Traverse(ray, trace_options, triangle_intersector);
-    return triangle_intersector.intersection.t;
+    bool hit = accel.Traverse(ray, triangle_intersector, &isect, trace_options);
+    return isect.t;
   };
   std::random_device rd;
   std::mt19937 gen(rd()); // we'll use this to generate rays on triangles
@@ -700,7 +699,7 @@ void SimplePolygonMesh::consistentlyOrientFaces(bool outwardOrient) {
     nanort::TriangleMesh<double> nanortMesh(rawPositions.data(), rawFaces.data(), sizeof(double) * 3);
     nanort::TriangleSAHPred<double> nanortMeshPred(rawPositions.data(), rawFaces.data(), sizeof(double) * 3);
     nanort::BVHBuildOptions<double> options; // Use default options
-    bool ret = accel.Build(nFaces(), options, nanortMesh, nanortMeshPred);
+    bool ret = accel.Build(nFaces(), nanortMesh, nanortMeshPred, options);
     if (!ret) {
       throw std::runtime_error("BVH construction failed");
     }


### PR DESCRIPTION
This PR updates the include path of nanort in geometry central to facilitate using the upstream [nanort](https://github.com/lighttransport/nanort) repository. I.e. users should `#include <nanort.h>` and not `<nanort/nanort.h>`.

Additionally, since nanort in geometry central is 8 years old, I though we could update it as well, as geometry central code isn't compatible with the latest nanort API.