### PR TITLE
Fix sign typo on "face Gaussian curvature" doc

### DIFF
--- a/docs/docs/surface/geometry/quantities.md
+++ b/docs/docs/surface/geometry/quantities.md
@@ -289,7 +289,7 @@ Different curvatures are available depending on whether geometry is intrinsic or
     
     ##### face Gaussian curvature
 
-    The [_Gaussian curvature_](https://en.wikipedia.org/wiki/Gaussian_curvature) $K$ at a face, defined via the rescaled angle defect in the face $K_f = \pi - \sum \tilde{\theta}_i$, where $\tilde{\theta}_i$ are the _rescaled_ corner angles (as in `cornerScaledAngles`) incident on the face.
+    The [_Gaussian curvature_](https://en.wikipedia.org/wiki/Gaussian_curvature) $K$ at a face, defined via the rescaled angle defect in the face $K_f = -\pi + \sum \tilde{\theta}_i$, where $\tilde{\theta}_i$ are the _rescaled_ corner angles (as in `cornerScaledAngles`) incident on the face.
 
     Should be interpreted as an _integrated_ Gaussian curvature, giving the total curvature inside of the face. A corresponding curvature-per-unit-area can be computed by dividing by the area of the face.
 


### PR DESCRIPTION
Hopefully the title is self-explanatory, there was a sign typo on the formula for computing the integrated Gaussian curvature on a face using the angle defect. The actual code doesn't have this typo, so this pull request only affects the docs.