### PR TITLE
Signed Fast Marching

### DIFF
--- a/docs/docs/surface/algorithms/geodesic_distance.md
+++ b/docs/docs/surface/algorithms/geodesic_distance.md
@@ -174,11 +174,11 @@ Computing exact geodesic paths also allows one to compute exact [log maps](/surf
 
     Returns the gradient of the distance function at `v` (i.e. the unit tangent vector at `v` which points away from the closest source)
 
-## (Signed) Fast Marching Method for Distance
+## Fast Marching Method for Distance
 
 These routines implement the _fast marching method_ (FMM) for geodesic distance on triangle meshes, as described by [Kimmel and Sethian 1998](https://www.pnas.org/doi/pdf/10.1073/pnas.95.15.8431). 
 
-This implementation allows the user to specify the sign of the initial velocity, allowing one to obtain either signed or unsigned distance to a set of closed curves. 
+This implementation allows you to obtain unsigned distance to a set of points, or signed distance to a set of curves. 
 
 Note that as a wave-based propagation method, if the source curves are not closed, then signed distance output is not guaranteed to be well-behaved; if you're looking for robust signed distance computation, consider the [Signed Heat Method routines](/surface/algorithms/signed_heat_method). If your curves are closed, then FMM will in general be more efficient.
 
@@ -188,13 +188,13 @@ Note that as a wave-based propagation method, if the source curves are not close
 
     Compute the distance from a source set of [Surface Points](/surface/utilities/surface_point/), initialized with the given distance values. 
 
-    If `sign` is false, computes unsigned distance. If `sign` is true, computes signed distance by interpreting the source points as a set of curves and propagating their orientation (gradient is continuous across the source).
+    If `sign` is false, computes unsigned distance. If `sign` is true, computes signed distance by interpreting the source points as a set of curves and propagating their orientation. 
 
 ??? func "`#!cpp VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry, const std::vector<std::pair<Vertex, double>>& initialDistances, bool sign = false)`"
 
     Compute the distance from a set of source vertices, initialized with the given distance values. 
 
-    If `sign` is false, computes unsigned distance. If `sign` is true, computes signed distance by interpreting the source vertices as a set of curves and propagating their orientation (gradient is continuous across the source).
+    If `sign` is false, computes unsigned distance. If `sign` is true, computes signed distance by interpreting the source vertices as a set of curves and propagating their orientation.
 
 Example
 ```cpp
@@ -215,6 +215,8 @@ initialDistances.emplace_back(mesh->vertex(8), 0.);
 VertexData<double> dist = FMMDistance(*geometry, initialDistances);
 /* do something useful */
 ```
+
+If computing signed distance, distances should be initialized to 0 on the source points.
 
 ## Heat Method for Distance
 

--- a/docs/docs/surface/algorithms/geodesic_distance.md
+++ b/docs/docs/surface/algorithms/geodesic_distance.md
@@ -178,7 +178,7 @@ Computing exact geodesic paths also allows one to compute exact [log maps](/surf
 
 These routines implement the _fast marching method_ (FMM) for geodesic distance on triangle meshes, as described by [Kimmel and Sethian 1998](https://www.pnas.org/doi/pdf/10.1073/pnas.95.15.8431). 
 
-This implementation allows you to obtain unsigned distance to a set of points, or signed distance to a set of curves. 
+This implementation allows you to obtain unsigned distance to a source set of points, or signed distance to a source set of curves, where the distance values on the source set may be initialized to any value. (When initial distances are not 0, "signed" means that the gradient of distance is continuous across the source curves.)
 
 Note that as a wave-based propagation method, if the source curves are not closed, then signed distance output is not guaranteed to be well-behaved; if you're looking for robust signed distance computation, consider the [Signed Heat Method routines](/surface/algorithms/signed_heat_method). If your curves are closed, then FMM will in general be more efficient.
 

--- a/docs/docs/surface/algorithms/geodesic_distance.md
+++ b/docs/docs/surface/algorithms/geodesic_distance.md
@@ -174,6 +174,48 @@ Computing exact geodesic paths also allows one to compute exact [log maps](/surf
 
     Returns the gradient of the distance function at `v` (i.e. the unit tangent vector at `v` which points away from the closest source)
 
+## (Signed) Fast Marching Method for Distance
+
+These routines implement the _fast marching method_ (FMM) for geodesic distance on triangle meshes, as described by [Kimmel and Sethian 1998](https://www.pnas.org/doi/pdf/10.1073/pnas.95.15.8431). 
+
+This implementation allows the user to specify the sign of the initial velocity, allowing one to obtain either signed or unsigned distance to a set of closed curves. 
+
+Note that as a wave-based propagation method, if the source curves are not closed, then signed distance output is not guaranteed to be well-behaved; if you're looking for robust signed distance computation, consider the [Signed Heat Method routines](/surface/algorithms/signed_heat_method). If your curves are closed, then FMM will in general be more efficient.
+
+`#include "geometrycentral/surface/fast_marching_method.h"`
+
+??? func "`#!cpp VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry, const std::vector<std::vector<std::pair<SurfacePoint, double>>>& initialDistances, bool sign = false)`"
+
+    Compute the distance from a source set of [Surface Points](/surface/utilities/surface_point/), initialized with the given distance values. 
+
+    If `sign` is false, computes unsigned distance. If `sign` is true, computes signed distance by interpreting the source points as a set of curves and propagating their orientation (gradient is continuous across the source).
+
+??? func "`#!cpp VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry, const std::vector<std::pair<Vertex, double>>& initialDistances, bool sign = false)`"
+
+    Compute the distance from a set of source vertices, initialized with the given distance values. 
+
+    If `sign` is false, computes unsigned distance. If `sign` is true, computes signed distance by interpreting the source vertices as a set of curves and propagating their orientation (gradient is continuous across the source).
+
+Example
+```cpp
+#include "geometrycentral/surface/fast_marching_method.h"
+#include "geometrycentral/surface/meshio.h"
+
+// Load a mesh
+std::unique_ptr<SurfaceMesh> mesh;
+std::unique_ptr<VertexPositionGeometry> geometry;
+std::tie(mesh, geometry) = loadMesh(filename);
+
+// Pick some vertices and initial distances.
+std::vector<std::pair<Vertex, double>> initialDistances;
+initialDistances.emplace_back(mesh->vertex(7), 0.);
+initialDistances.emplace_back(mesh->vertex(8), 0.);
+
+// Compute distance
+VertexData<double> dist = FMMDistance(*geometry, initialDistances);
+/* do something useful */
+```
+
 ## Heat Method for Distance
 
 These routines implement the [Heat Method for Geodesic Distance](http://www.cs.cmu.edu/~kmcrane/Projects/HeatMethod/paper.pdf). This algorithm uses short time heat flow to compute distance on surfaces. Because the main burden is simply solving linear systems of equations, it tends to be faster than polyhedral schemes, especially when computing distance multiple times on the same surface.  In the computational geometry sense, this method is an approximation, as the result is not precisely equal to the polyhedral distance on the surface; nonetheless it is fast and well-suited for many applications.

--- a/include/geometrycentral/surface/barycentric_vector.ipp
+++ b/include/geometrycentral/surface/barycentric_vector.ipp
@@ -531,8 +531,8 @@ inline Face sharedFace(const BarycentricVector& u, const BarycentricVector& w) {
     case BarycentricVectorType::Vertex:
       for (Vertex v : u.face.adjacentVertices()) {
         if (v == w.vertex) return u.face;
-        break;
       }
+      break;
     }
     break;
   }

--- a/include/geometrycentral/surface/fast_marching_method.h
+++ b/include/geometrycentral/surface/fast_marching_method.h
@@ -18,7 +18,7 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
                                bool sign = false);
 
 VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
-                               const std::vector<std::pair<Vertex, double>>& initialDistances);
+                               const std::vector<std::pair<Vertex, double>>& initialDistances, bool sign = false);
 
 
 } // namespace surface

--- a/include/geometrycentral/surface/fast_marching_method.h
+++ b/include/geometrycentral/surface/fast_marching_method.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "geometrycentral/surface/barycentric_vector.h"
 #include "geometrycentral/surface/intrinsic_geometry_interface.h"
+#include "geometrycentral/surface/surface_point.h"
 #include "geometrycentral/utilities/utilities.h"
 
 #include <cmath>
@@ -10,6 +12,10 @@
 
 namespace geometrycentral {
 namespace surface {
+
+VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
+                               const std::vector<std::vector<std::pair<SurfacePoint, double>>>& initialDistances,
+                               bool sign = false);
 
 VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
                                const std::vector<std::pair<Vertex, double>>& initialDistances);

--- a/src/surface/fast_marching_method.cpp
+++ b/src/surface/fast_marching_method.cpp
@@ -11,7 +11,7 @@ namespace {
 
 // The super fun quadratic distance function in the Fast Marching Method on triangle meshes
 // TODO parameter c isn't actually defined in paper, so I guessed that it was an error
-double eikonalDistanceSubroutine(double a, double b, double theta, double dA, double dB) {
+double eikonalDistanceSubroutine(double a, double b, double theta, double dA, double dB, int sign) {
 
 
   if (theta <= PI / 2.0) {
@@ -24,24 +24,25 @@ double eikonalDistanceSubroutine(double a, double b, double theta, double dA, do
     double quadB = 2 * b * u * (a * cTheta - b);
     double quadC = b * b * (u * u - a * a * sTheta2);
     double sqrtVal = std::sqrt(quadB * quadB - 4 * quadA * quadC);
-    double t = (-quadB + sqrtVal) / (2 * quadA); // always the positive root (negative root corresponds to slope -1)
-    if (u < t && a * cTheta < b * (t - u) / t && b * (t - u) / t < a / cTheta) {
+    double tVals[] = {(-quadB + sqrtVal) / (2 * quadA), (-quadB - sqrtVal) / (2 * quadA)};
+    double t = sign > 0 ? tVals[0] : tVals[1];
+    double y = b * (t - u) / t;
+    if (u < sign * t && a * cTheta < y && y < a / cTheta) {
       return dA + t;
     } else {
-      return std::min(b + dA, a + dB);
+      return std::min(b * sign + dA, a * sign + dB);
     }
 
   }
   // Custom by Nick to get acceptable results in obtuse triangles without fancy unfolding
   else {
-
-    double maxDist = std::max(dA, dB); // all points on base are less than this far away, by convexity
+    double maxDist = std::max(sign * dA, sign * dB); // all points on base are less than this far away, by convexity
     double c = std::sqrt(a * a + b * b - 2 * a * b * std::cos(theta));
     double area = 0.5 * std::sin(theta) * a * b;
     double altitude = 2 * area / c; // distance to base, must be inside triangle since obtuse
     double baseDist = maxDist + altitude;
 
-    return std::min({b + dA, a + dB, baseDist});
+    return std::min({b * sign + dA, a * sign + dB, sign * baseDist});
   }
 }
 
@@ -67,8 +68,17 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
   VertexData<double> distances(mesh, std::numeric_limits<double>::infinity());
   VertexData<int> signs(mesh, 1);
   VertexData<char> finalized(mesh, false);
+  VertexData<char> isSource(mesh, false);
 
-  std::priority_queue<Entry, std::vector<Entry>, std::greater<Entry>> frontierPQ;
+  auto cmp = [&signs](Entry left, Entry right) {
+    if (signs[left.second] != signs[right.second]) {
+      // We're looking at an edge that intersects the source, which may not have initial distance 0.
+      // I *think* this can only happen if the positive vertex lies on the source, in which case it's the "closer" one.
+      return signs[left.second] != 1;
+    }
+    return signs[left.second] * left.first > signs[right.second] * right.first;
+  };
+  std::priority_queue<Entry, std::vector<Entry>, decltype(cmp)> frontierPQ(cmp);
   // Initialize signs
   if (sign) {
     for (Vertex v : mesh.vertices()) signs[v] = 0;
@@ -126,24 +136,24 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
       }
     }
   }
-  // Initialize distances. It's also possible to propagate signed distances and define eikonalDistanceSubroutine()
-  // accordingly, but it gets cumbersome managing directions of inequalities, and initializing distances of unvisited
-  // vertices as +/-inf. So just compute unsigned distances, then sign -- rather than try to actually solve the true
-  // BVP.
+  // Initialize distances.
   for (auto& curve : initialDistances) {
     for (auto& x : curve) {
       const SurfacePoint& p = x.first;
       switch (p.type) {
       case (SurfacePointType::Vertex): {
         frontierPQ.push(std::make_pair(x.second, p.vertex));
+        isSource[p.vertex] = true;
         break;
       }
       case (SurfacePointType::Edge): {
         const Vertex& vA = p.edge.firstVertex();
         const Vertex& vB = p.edge.secondVertex();
         double l = geometry.edgeLengths[p.edge];
-        frontierPQ.push(std::make_pair(x.second + p.tEdge * l, vA));
-        frontierPQ.push(std::make_pair(x.second + (1. - p.tEdge) * l, vB));
+        frontierPQ.push(std::make_pair(x.second + signs[vA] * p.tEdge * l, vA));
+        frontierPQ.push(std::make_pair(x.second + signs[vB] * (1. - p.tEdge) * l, vB));
+        isSource[vA] = true;
+        isSource[vB] = true;
         break;
       }
       case (SurfacePointType::Face): {
@@ -163,9 +173,12 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
         double dist2_A = lAB2 * (v * (1. - u)) + lCA2 * (w * (1. - u)) - lAB2 * v * w; // squared distance from p to vA
         double dist2_B = lAB2 * (u * (1. - v)) + lBC2 * (w * (1. - v)) - lCA2 * u * w; // squared distance from p to vB
         double dist2_C = lCA2 * (u * (1. - w)) + lBC2 * (v * (1. - w)) - lBC2 * u * v; // squared distance from p to vC
-        frontierPQ.push(std::make_pair(x.second + std::sqrt(dist2_A), vA));
-        frontierPQ.push(std::make_pair(x.second + std::sqrt(dist2_B), vB));
-        frontierPQ.push(std::make_pair(x.second + std::sqrt(dist2_C), vC));
+        frontierPQ.push(std::make_pair(x.second + signs[vA] * std::sqrt(dist2_A), vA));
+        frontierPQ.push(std::make_pair(x.second + signs[vB] * std::sqrt(dist2_B), vB));
+        frontierPQ.push(std::make_pair(x.second + signs[vC] * std::sqrt(dist2_C), vC));
+        isSource[vA] = true;
+        isSource[vB] = true;
+        isSource[vC] = true;
         break;
       }
       }
@@ -197,10 +210,10 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
       Vertex neighVert = he.vertex();
 
       // Add with length
-      if (!finalized[neighVert]) {
+      if (!finalized[neighVert] && !isSource[neighVert]) {
         if (signs[neighVert] == 0) signs[neighVert] = signs[currV];
-        double newDist = currDist + geometry.edgeLengths[he.edge()];
-        if (newDist < distances[neighVert]) {
+        double newDist = currDist + signs[neighVert] * geometry.edgeLengths[he.edge()];
+        if (signs[neighVert] * newDist < signs[neighVert] * distances[neighVert] || std::isinf(distances[neighVert])) {
           frontierPQ.push(std::make_pair(newDist, neighVert));
           distances[neighVert] = newDist;
         }
@@ -210,7 +223,7 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
       // Check the third point of the "left" triangle straddling this edge
       if (he.isInterior()) {
         Vertex newVert = he.next().next().vertex();
-        if (!finalized[newVert]) {
+        if (!finalized[newVert] && !isSource[newVert]) {
 
           // Compute the distance
           double lenB = geometry.edgeLengths[he.next().next().edge()];
@@ -219,8 +232,8 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
           double distA = distances[neighVert];
           double theta = geometry.cornerAngles[he.next().next().corner()];
           if (signs[newVert] == 0) signs[newVert] = (signs[currV] != 0) ? signs[currV] : signs[he.next().vertex()];
-          double newDist = eikonalDistanceSubroutine(lenA, lenB, theta, distA, distB);
-          if (newDist < distances[newVert]) {
+          double newDist = eikonalDistanceSubroutine(lenA, lenB, theta, distA, distB, signs[newVert]);
+          if (signs[newVert] * newDist < signs[newVert] * distances[newVert] || std::isinf(distances[newVert])) {
             frontierPQ.push(std::make_pair(newDist, newVert));
             distances[newVert] = newDist;
           }
@@ -231,7 +244,7 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
       Halfedge heT = he.twin();
       if (heT.isInterior()) {
         Vertex newVert = heT.next().next().vertex();
-        if (!finalized[newVert]) {
+        if (!finalized[newVert] && !isSource[newVert]) {
 
           // Compute the distance
           double lenB = geometry.edgeLengths[heT.next().edge()];
@@ -240,8 +253,8 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
           double distA = distances[neighVert];
           double theta = geometry.cornerAngles[heT.next().next().corner()];
           if (signs[newVert] == 0) signs[newVert] = (signs[currV] != 0) ? signs[currV] : signs[he.next().vertex()];
-          double newDist = eikonalDistanceSubroutine(lenA, lenB, theta, distA, distB);
-          if (newDist < distances[newVert]) {
+          double newDist = eikonalDistanceSubroutine(lenA, lenB, theta, distA, distB, signs[newVert]);
+          if (signs[newVert] * newDist < signs[newVert] * distances[newVert] || std::isinf(distances[newVert])) {
             frontierPQ.push(std::make_pair(newDist, newVert));
             distances[newVert] = newDist;
           }
@@ -249,8 +262,7 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
       }
     }
   }
-  // Sign unsigned distances. This will probably only do something reasonable if the curves are closed.
-  for (Vertex v : mesh.vertices()) distances[v] *= signs[v];
+
   return distances;
 }
 

--- a/src/surface/fast_marching_method.cpp
+++ b/src/surface/fast_marching_method.cpp
@@ -127,8 +127,9 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
     }
   }
   // Initialize distances. It's also possible to propagate signed distances and define eikonalDistanceSubroutine()
-  // accordingly, but it gets tricky initializing distances of unvisited vertices as +/-inf. So just compute unsigned
-  // distances, then sign -- rather than try to propagate signed distance.
+  // accordingly, but it gets cumbersome managing directions of inequalities, and initializing distances of unvisited
+  // vertices as +/-inf. So just compute unsigned distances, then sign -- rather than try to actually solve the true
+  // BVP.
   for (auto& curve : initialDistances) {
     for (auto& x : curve) {
       const SurfacePoint& p = x.first;


### PR DESCRIPTION
Extend the existing fast marching method in `surface/fast_marching_method.cpp` to
* Take as input `SurfacePoint`s rather than just vertices
* Allow computation of unsigned or signed distance (where the source geometry may not necessarily be initialized to 0)