### PR TITLE
Bump Eigen version to 3.3.9

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -72,7 +72,7 @@ else()
       FetchContent_Declare(
           eigen
           GIT_REPOSITORY  https://gitlab.com/libeigen/eigen.git
-          GIT_TAG         3.3.8
+          GIT_TAG         3.3.9
           SOURCE_DIR      "${CMAKE_CURRENT_BINARY_DIR}/eigen-src"
           BINARY_DIR      "${CMAKE_CURRENT_BINARY_DIR}/eigen-build"
       )


### PR DESCRIPTION
Eigen 3.3.8 is [known to have a bug](https://gitlab.com/libeigen/eigen/-/issues/2011). Somehow geometry-central and its tests never trigger the problematic code, but is sometimes triggered when geometry-central is used within other projects (and only on Linux, but not on Mac -- I guess the codepath is different on macOS vs. linux). The bug is fixed in the next version.