### PR TITLE
Fix: clear m_stop_vertices unconditionally in set_stop_conditions

### DIFF
--- a/src/surface/exact_geodesics.cpp
+++ b/src/surface/exact_geodesics.cpp
@@ -1343,8 +1343,8 @@ IntervalList GeodesicAlgorithmExact::getEdgeIntervals(Edge e) const { return m_e
 void GeodesicAlgorithmExact::set_stop_conditions(const std::vector<SurfacePoint>& stop_points, double stop_distance) {
   m_max_propagation_distance = stop_distance;
 
+  m_stop_vertices.clear();
   if (stop_points.empty()) {
-    m_stop_vertices.clear();
     return;
   }
 


### PR DESCRIPTION
Clear `m_stop_vertices` unconditionally in `set_stop_conditions` to prevent stale stop vertex accumulation when reusing `GeodesicAlgorithmExact` instances across multiple `propagate()` calls.