### PR TITLE
fix(cmake): use dependency targets for build-tree consumers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -175,23 +175,21 @@ SET(HEADERS
 # Create a single library for the project
 add_library(geometry-central ${SRCS} ${HEADERS})
 
-# Public headers include vendored headers directly, so build-tree consumers need
-# those include roots explicitly. The install tree collapses them under the
-# single installed include directory.
 target_include_directories(geometry-central
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-    $<BUILD_INTERFACE:${EIGEN3_INCLUDE_DIR}>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../deps/happly>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-  PRIVATE
-    "${CMAKE_CURRENT_SOURCE_DIR}/../deps/nanoflann/include"
-    "${CMAKE_CURRENT_SOURCE_DIR}/../deps/nanort/include"
-)
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-# Keep Eigen out of the exported build-tree link interface to avoid exporting the
-# local helper target created in deps/CMakeLists.txt. The installed package adds
-# Eigen3::Eigen back after calling find_dependency(Eigen3).
+target_link_libraries(geometry-central
+  PUBLIC
+    $<BUILD_INTERFACE:Eigen3::Eigen>
+    $<BUILD_INTERFACE:happly>
+  PRIVATE
+    $<BUILD_INTERFACE:nanoflann>
+    $<BUILD_INTERFACE:nanort>)
+
+# Keep build-tree dependency targets out of the installed export. The installed
+# package adds Eigen3::Eigen back after calling find_dependency(Eigen3).
 
 # Set compiler properties for the library
 target_compile_features(geometry-central PUBLIC cxx_std_11)


### PR DESCRIPTION
## Summary

Fix `geometry-central`'s CMake target interface so build-tree consumers can override dependency targets while preserving the install/package behavior added for Nix.

## What Changed

- Replaced hardcoded dependency include paths with target-based links.
- Linked `Eigen3::Eigen` and `happly` publicly for build-tree consumers.
- Linked `nanoflann` and `nanort` privately for build-tree consumers.
- Kept dependency target links scoped to `BUILD_INTERFACE` so the installed export remains clean.

## Why

This addresses concerns raised on #190  about #238  making `add_subdirectory()` consumers use geometry-central's vendored dependency paths directly. Consumers can now provide their own compatible `Eigen3::Eigen`, `happly`, `nanoflann`, or `nanort` targets.

The installed package path from #238  is preserved: installed consumers still use `find_package(GeometryCentral CONFIG)` and inherit `Eigen3::Eigen` through the generated package config.

I intentionally kept the build-tree include path absolute with `${CMAKE_CURRENT_SOURCE_DIR}/../include` rather than using a relative `$<BUILD_INTERFACE:../include>`. CMake documents that relative paths are allowed inside `INSTALL_INTERFACE`, where they are interpreted relative to the install prefix, but relative paths should not be used inside `BUILD_INTERFACE` because they are not converted to absolute paths. See: https://cmake.org/cmake/help/latest/command/target_include_directories.html

## Verification

- Configured geometry-central with `SUITESPARSE=OFF`
- Built `geometry-central`
- Installed geometry-central
- Verified downstream `find_package(GeometryCentral REQUIRED CONFIG)` smoke build
- Verified downstream `add_subdirectory()` smoke build with predeclared dependency targets
