### PR TITLE
SurfacePoint::inEdge: fix reversed tEdge for Vertex-typed points

### DIFF
--- a/include/geometrycentral/surface/surface_point.ipp
+++ b/include/geometrycentral/surface/surface_point.ipp
@@ -151,9 +151,9 @@ inline SurfacePoint SurfacePoint::inEdge(Edge targetEdge) const {
   switch (type) {
   case SurfacePointType::Vertex:
     if (vertex == targetEdge.halfedge().tailVertex()) {
-      return SurfacePoint(targetEdge, 1);
-    } else if (vertex == targetEdge.halfedge().tipVertex()) {
       return SurfacePoint(targetEdge, 0);
+    } else if (vertex == targetEdge.halfedge().tipVertex()) {
+      return SurfacePoint(targetEdge, 1);
     }
     break;
   case SurfacePointType::Edge:


### PR DESCRIPTION
Minimal two-line fix for #245.

`SurfacePoint::inEdge` on a `Vertex`-typed point returns the reflected edge
parameter — `tEdge=1` for `edge.halfedge().tailVertex()`, `0` for the tip —
which contradicts the rest of `surface_point.ipp` (`interpolate`, the
`SurfacePoint(Edge, double)` ctor, `nearestVertex`), where `tEdge=0` is the tail
and `tEdge=1` is the tip. Downstream this mis-places every shared-edge
`insertVertex(SurfacePoint(edge, t))` at parameter `(1 - t)` instead of `t`,
producing visible Steiner drift in an intrinsic-triangulation pipeline.

The fix swaps the two return values so the Vertex-typed branch matches the
documented convention.

Full writeup + single-triangle MWE: #245.

Note: I noticed the (unmerged) `int-tri-updates` branch reworks `inEdge` more
broadly — happy to defer to that approach if you'd rather pick it back up; this
is just the minimal correctness fix against current `master`.

Fixes #245.
