### PR TITLE
delaunayRefine: guard against inserting a circumcenter coincident with an existing vertex

### DIFF
--- a/src/surface/intrinsic_triangulation.cpp
+++ b/src/surface/intrinsic_triangulation.cpp
@@ -282,7 +282,30 @@ Vertex IntrinsicTriangulation::insertCircumcenter(Face f) {
   }
 
   // === Phase 3: Add the new vertex
-  return insertVertex(newPositionOnIntrinsic);
+  Vertex newV = insertVertex(newPositionOnIntrinsic);
+
+  // Proximity guard: a traced circumcenter can land coincident with an existing
+  // vertex (it ends as a Face/Edge point on a triangle corner). This happens on
+  // *constrained* triangulations near small input angles, where a bad triangle's
+  // circumcircle is effectively centered on an existing vertex. Inserting such a
+  // point creates a zero-area (needle) triangle that poisons downstream solves.
+  // Detect the resulting near-zero incident edge and undo the insertion;
+  // delaunayRefine() treats a Vertex() return as "insertion failed" and simply
+  // leaves that triangle unrefined (which is the correct behavior near an
+  // unrefinable constrained corner).
+  if (newV != Vertex()) {
+    double minInc = std::numeric_limits<double>::infinity();
+    double maxInc = 0.;
+    for (Edge e : newV.adjacentEdges()) {
+      minInc = std::min(minInc, edgeLengths[e]);
+      maxInc = std::max(maxInc, edgeLengths[e]);
+    }
+    if (minInc <= 1e-9 * maxInc) {
+      removeInsertedVertex(newV);
+      return Vertex();
+    }
+  }
+  return newV;
 }
 
 Vertex IntrinsicTriangulation::insertBarycenter(Face f) {


### PR DESCRIPTION
Fix for #246.

Constrained `delaunayRefine` (edges fixed via `setMarkedEdges`) can trace a
circumcenter onto an existing vertex — it ends as a `Face` point on a triangle
corner — producing a zero-area "needle" triangle (min angle 0°, ~1e-9 edge)
that then poisons downstream cotan-Laplacian / BFF solves. The *same* mesh and
metric refine cleanly to the angle bound when no interior edges are marked, so
only the segment-constrained path hits it.

This adds a proximity guard in `IntrinsicTriangulation::insertCircumcenter`:
after `insertVertex`, if the new vertex has a near-zero incident edge
(`minInc <= 1e-9 * maxInc`) it landed on existing geometry, so undo the
insertion and return `Vertex()`. `delaunayRefine` already treats a `Vertex()`
return as "insertion failed" and continues, leaving the unrefinable constrained
corner as a healthy (non-degenerate) triangle.

On the reproducer in #246 (stock build, otherwise unchanged): constrained refine
**0° → 4.21°**, no degeneracy, deterministic; the unmarked control on the
identical mesh is **unchanged at 25.12°**.

Full analysis + runnable reproducer: #246.

Fixes #246.
