### PR TITLE
fix: correct FMM source propagation

### DIFF
--- a/src/surface/fast_marching_method.cpp
+++ b/src/surface/fast_marching_method.cpp
@@ -56,7 +56,7 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
                                const std::vector<std::vector<std::pair<SurfacePoint, double>>>& initialDistances,
                                bool sign) {
 
-  typedef std::pair<double, Vertex> Entry;
+  typedef std::tuple<double, Vertex, int> Entry;
 
   SurfaceMesh& mesh = geometry.mesh;
   geometry.requireEdgeLengths();
@@ -72,14 +72,20 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
   VertexData<int> signs(mesh, 1);
   VertexData<char> finalized(mesh, false);
   VertexData<char> isSource(mesh, false);
+  VertexData<int> sourceLabels(mesh, -1);
+  EdgeData<char> isSourceBaseEdge(mesh, false);
+  EdgeData<int> sourceBaseLabels(mesh, -1);
+  int nextSourceLabel = 0;
 
   auto cmp = [&signs](Entry left, Entry right) {
-    if (signs[left.second] != signs[right.second]) {
+    Vertex leftV = std::get<1>(left);
+    Vertex rightV = std::get<1>(right);
+    if (signs[leftV] != signs[rightV]) {
       // We're looking at an edge that intersects the source, which may not have initial distance 0.
       // I *think* this can only happen if the positive vertex lies on the source, in which case it's the "closer" one.
-      return signs[left.second] != 1;
+      return signs[leftV] != 1;
     }
-    return signs[left.second] * left.first > signs[right.second] * right.first;
+    return signs[leftV] * std::get<0>(left) > signs[rightV] * std::get<0>(right);
   };
   std::priority_queue<Entry, std::vector<Entry>, decltype(cmp)> frontierPQ(cmp);
 
@@ -90,10 +96,16 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
     return signs[v] * candidateDist < signs[v] * distances[v];
   };
 
-  auto addCandidateDistance = [&](Vertex v, double candidateDist) {
+  auto addCandidateDistance = [&](Vertex v, double candidateDist, int sourceLabel) {
     if (!candidateImprovesDistance(v, candidateDist)) return;
     distances[v] = candidateDist;
-    frontierPQ.push(std::make_pair(candidateDist, v));
+    sourceLabels[v] = sourceLabel;
+    frontierPQ.push(std::make_tuple(candidateDist, v, sourceLabel));
+  };
+
+  auto markSourceBaseEdge = [&](Edge e, int sourceLabel) {
+    isSourceBaseEdge[e] = true;
+    if (sourceBaseLabels[e] == -1) sourceBaseLabels[e] = sourceLabel;
   };
 
   // Initialize signs
@@ -123,6 +135,13 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
             signs[v] = (dot(geometry, normal, u) > 0) ? 1 : -1;
           }
         }
+      }
+    }
+    for (auto& curve : initialDistances) {
+      size_t nNodes = curve.size();
+      for (size_t i = 0; i < nNodes - 1; i++) {
+        Edge commonEdge = sharedEdge(curve[i].first, curve[i + 1].first);
+        if (commonEdge != Edge()) markSourceBaseEdge(commonEdge, nextSourceLabel++);
       }
     }
     // Vertices on the curve are always assumed to have positive sign.
@@ -157,9 +176,10 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
   for (auto& curve : initialDistances) {
     for (auto& x : curve) {
       const SurfacePoint& p = x.first;
+      int sourceLabel = nextSourceLabel++;
       switch (p.type) {
       case (SurfacePointType::Vertex): {
-        addCandidateDistance(p.vertex, x.second);
+        addCandidateDistance(p.vertex, x.second, sourceLabel);
         isSource[p.vertex] = true;
         break;
       }
@@ -167,10 +187,11 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
         const Vertex& vA = p.edge.firstVertex();
         const Vertex& vB = p.edge.secondVertex();
         double l = geometry.edgeLengths[p.edge];
-        addCandidateDistance(vA, x.second + signs[vA] * p.tEdge * l);
-        addCandidateDistance(vB, x.second + signs[vB] * (1. - p.tEdge) * l);
+        addCandidateDistance(vA, x.second + signs[vA] * p.tEdge * l, sourceLabel);
+        addCandidateDistance(vB, x.second + signs[vB] * (1. - p.tEdge) * l, sourceLabel);
         isSource[vA] = true;
         isSource[vB] = true;
+        markSourceBaseEdge(p.edge, sourceLabel);
         break;
       }
       case (SurfacePointType::Face): {
@@ -190,12 +211,15 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
         double dist2_A = lAB2 * (v * (1. - u)) + lCA2 * (w * (1. - u)) - lBC2 * v * w; // squared distance from p to vA
         double dist2_B = lAB2 * (u * (1. - v)) + lBC2 * (w * (1. - v)) - lCA2 * u * w; // squared distance from p to vB
         double dist2_C = lCA2 * (u * (1. - w)) + lBC2 * (v * (1. - w)) - lAB2 * u * v; // squared distance from p to vC
-        addCandidateDistance(vA, x.second + signs[vA] * std::sqrt(std::max(0., dist2_A)));
-        addCandidateDistance(vB, x.second + signs[vB] * std::sqrt(std::max(0., dist2_B)));
-        addCandidateDistance(vC, x.second + signs[vC] * std::sqrt(std::max(0., dist2_C)));
+        addCandidateDistance(vA, x.second + signs[vA] * std::sqrt(std::max(0., dist2_A)), sourceLabel);
+        addCandidateDistance(vB, x.second + signs[vB] * std::sqrt(std::max(0., dist2_B)), sourceLabel);
+        addCandidateDistance(vC, x.second + signs[vC] * std::sqrt(std::max(0., dist2_C)), sourceLabel);
         isSource[vA] = true;
         isSource[vB] = true;
         isSource[vC] = true;
+        markSourceBaseEdge(he.edge(), sourceLabel);
+        markSourceBaseEdge(he.next().edge(), sourceLabel);
+        markSourceBaseEdge(he.next().next().edge(), sourceLabel);
         break;
       }
       }
@@ -211,12 +235,13 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
     // Pop the nearest element
     Entry currPair = frontierPQ.top();
     frontierPQ.pop();
-    Vertex currV = currPair.second;
-    double currDist = currPair.first;
+    double currDist = std::get<0>(currPair);
+    Vertex currV = std::get<1>(currPair);
+    int currSourceLabel = std::get<2>(currPair);
 
 
     // Accept it if not stale
-    if (finalized[currV]) {
+    if (finalized[currV] || currDist != distances[currV] || currSourceLabel != sourceLabels[currV]) {
       continue;
     }
     distances[currV] = currDist;
@@ -231,9 +256,14 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
       if (!finalized[neighVert] && !isSource[neighVert]) {
         if (signs[neighVert] == 0) signs[neighVert] = signs[currV];
         double newDist = currDist + signs[neighVert] * geometry.edgeLengths[he.edge()];
-        addCandidateDistance(neighVert, newDist);
+        addCandidateDistance(neighVert, newDist, currSourceLabel);
         continue;
       }
+
+      bool useSourceBaseEdge = sourceLabels[neighVert] != currSourceLabel && isSource[currV] && isSource[neighVert] &&
+                               isSourceBaseEdge[he.edge()];
+      if (sourceLabels[neighVert] != currSourceLabel && !useSourceBaseEdge) continue;
+      int updateSourceLabel = useSourceBaseEdge ? sourceBaseLabels[he.edge()] : currSourceLabel;
 
       // Check the third point of the "left" triangle straddling this edge
       if (he.isInterior()) {
@@ -248,7 +278,7 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
           double theta = geometry.cornerAngles[he.next().next().corner()];
           if (signs[newVert] == 0) signs[newVert] = (signs[currV] != 0) ? signs[currV] : signs[he.next().vertex()];
           double newDist = eikonalDistanceSubroutine(lenA, lenB, theta, distA, distB, signs[newVert]);
-          addCandidateDistance(newVert, newDist);
+          addCandidateDistance(newVert, newDist, updateSourceLabel);
         }
       }
 
@@ -266,7 +296,7 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
           double theta = geometry.cornerAngles[heT.next().next().corner()];
           if (signs[newVert] == 0) signs[newVert] = (signs[currV] != 0) ? signs[currV] : signs[he.next().vertex()];
           double newDist = eikonalDistanceSubroutine(lenA, lenB, theta, distA, distB, signs[newVert]);
-          addCandidateDistance(newVert, newDist);
+          addCandidateDistance(newVert, newDist, updateSourceLabel);
         }
       }
     }

--- a/src/surface/fast_marching_method.cpp
+++ b/src/surface/fast_marching_method.cpp
@@ -187,12 +187,12 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
         double u = p.faceCoords[0];
         double v = p.faceCoords[1];
         double w = p.faceCoords[2];
-        double dist2_A = lAB2 * (v * (1. - u)) + lCA2 * (w * (1. - u)) - lAB2 * v * w; // squared distance from p to vA
+        double dist2_A = lAB2 * (v * (1. - u)) + lCA2 * (w * (1. - u)) - lBC2 * v * w; // squared distance from p to vA
         double dist2_B = lAB2 * (u * (1. - v)) + lBC2 * (w * (1. - v)) - lCA2 * u * w; // squared distance from p to vB
-        double dist2_C = lCA2 * (u * (1. - w)) + lBC2 * (v * (1. - w)) - lBC2 * u * v; // squared distance from p to vC
-        addCandidateDistance(vA, x.second + signs[vA] * std::sqrt(dist2_A));
-        addCandidateDistance(vB, x.second + signs[vB] * std::sqrt(dist2_B));
-        addCandidateDistance(vC, x.second + signs[vC] * std::sqrt(dist2_C));
+        double dist2_C = lCA2 * (u * (1. - w)) + lBC2 * (v * (1. - w)) - lAB2 * u * v; // squared distance from p to vC
+        addCandidateDistance(vA, x.second + signs[vA] * std::sqrt(std::max(0., dist2_A)));
+        addCandidateDistance(vB, x.second + signs[vB] * std::sqrt(std::max(0., dist2_B)));
+        addCandidateDistance(vC, x.second + signs[vC] * std::sqrt(std::max(0., dist2_C)));
         isSource[vA] = true;
         isSource[vB] = true;
         isSource[vC] = true;

--- a/src/surface/fast_marching_method.cpp
+++ b/src/surface/fast_marching_method.cpp
@@ -1,5 +1,8 @@
 #include "geometrycentral/surface/fast_marching_method.h"
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
 #include <queue>
 #include <tuple>
 
@@ -79,6 +82,20 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
     return signs[left.second] * left.first > signs[right.second] * right.first;
   };
   std::priority_queue<Entry, std::vector<Entry>, decltype(cmp)> frontierPQ(cmp);
+
+  auto candidateImprovesDistance = [&](Vertex v, double candidateDist) {
+    if (!std::isfinite(candidateDist)) return false;
+    if (!std::isfinite(distances[v])) return true;
+    if (signs[v] == 0) return std::abs(candidateDist) < std::abs(distances[v]);
+    return signs[v] * candidateDist < signs[v] * distances[v];
+  };
+
+  auto addCandidateDistance = [&](Vertex v, double candidateDist) {
+    if (!candidateImprovesDistance(v, candidateDist)) return;
+    distances[v] = candidateDist;
+    frontierPQ.push(std::make_pair(candidateDist, v));
+  };
+
   // Initialize signs
   if (sign) {
     for (Vertex v : mesh.vertices()) signs[v] = 0;
@@ -142,7 +159,7 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
       const SurfacePoint& p = x.first;
       switch (p.type) {
       case (SurfacePointType::Vertex): {
-        frontierPQ.push(std::make_pair(x.second, p.vertex));
+        addCandidateDistance(p.vertex, x.second);
         isSource[p.vertex] = true;
         break;
       }
@@ -150,8 +167,8 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
         const Vertex& vA = p.edge.firstVertex();
         const Vertex& vB = p.edge.secondVertex();
         double l = geometry.edgeLengths[p.edge];
-        frontierPQ.push(std::make_pair(x.second + signs[vA] * p.tEdge * l, vA));
-        frontierPQ.push(std::make_pair(x.second + signs[vB] * (1. - p.tEdge) * l, vB));
+        addCandidateDistance(vA, x.second + signs[vA] * p.tEdge * l);
+        addCandidateDistance(vB, x.second + signs[vB] * (1. - p.tEdge) * l);
         isSource[vA] = true;
         isSource[vB] = true;
         break;
@@ -173,9 +190,9 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
         double dist2_A = lAB2 * (v * (1. - u)) + lCA2 * (w * (1. - u)) - lAB2 * v * w; // squared distance from p to vA
         double dist2_B = lAB2 * (u * (1. - v)) + lBC2 * (w * (1. - v)) - lCA2 * u * w; // squared distance from p to vB
         double dist2_C = lCA2 * (u * (1. - w)) + lBC2 * (v * (1. - w)) - lBC2 * u * v; // squared distance from p to vC
-        frontierPQ.push(std::make_pair(x.second + signs[vA] * std::sqrt(dist2_A), vA));
-        frontierPQ.push(std::make_pair(x.second + signs[vB] * std::sqrt(dist2_B), vB));
-        frontierPQ.push(std::make_pair(x.second + signs[vC] * std::sqrt(dist2_C), vC));
+        addCandidateDistance(vA, x.second + signs[vA] * std::sqrt(dist2_A));
+        addCandidateDistance(vB, x.second + signs[vB] * std::sqrt(dist2_B));
+        addCandidateDistance(vC, x.second + signs[vC] * std::sqrt(dist2_C));
         isSource[vA] = true;
         isSource[vB] = true;
         isSource[vC] = true;
@@ -184,6 +201,7 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
       }
     }
   }
+
   size_t nFound = 0;
   size_t nVert = mesh.nVertices();
 
@@ -213,10 +231,7 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
       if (!finalized[neighVert] && !isSource[neighVert]) {
         if (signs[neighVert] == 0) signs[neighVert] = signs[currV];
         double newDist = currDist + signs[neighVert] * geometry.edgeLengths[he.edge()];
-        if (signs[neighVert] * newDist < signs[neighVert] * distances[neighVert] || std::isinf(distances[neighVert])) {
-          frontierPQ.push(std::make_pair(newDist, neighVert));
-          distances[neighVert] = newDist;
-        }
+        addCandidateDistance(neighVert, newDist);
         continue;
       }
 
@@ -233,10 +248,7 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
           double theta = geometry.cornerAngles[he.next().next().corner()];
           if (signs[newVert] == 0) signs[newVert] = (signs[currV] != 0) ? signs[currV] : signs[he.next().vertex()];
           double newDist = eikonalDistanceSubroutine(lenA, lenB, theta, distA, distB, signs[newVert]);
-          if (signs[newVert] * newDist < signs[newVert] * distances[newVert] || std::isinf(distances[newVert])) {
-            frontierPQ.push(std::make_pair(newDist, newVert));
-            distances[newVert] = newDist;
-          }
+          addCandidateDistance(newVert, newDist);
         }
       }
 
@@ -254,10 +266,7 @@ VertexData<double> FMMDistance(IntrinsicGeometryInterface& geometry,
           double theta = geometry.cornerAngles[heT.next().next().corner()];
           if (signs[newVert] == 0) signs[newVert] = (signs[currV] != 0) ? signs[currV] : signs[he.next().vertex()];
           double newDist = eikonalDistanceSubroutine(lenA, lenB, theta, distA, distB, signs[newVert]);
-          if (signs[newVert] * newDist < signs[newVert] * distances[newVert] || std::isinf(distances[newVert])) {
-            frontierPQ.push(std::make_pair(newDist, newVert));
-            distances[newVert] = newDist;
-          }
+          addCandidateDistance(newVert, newDist);
         }
       }
     }


### PR DESCRIPTION
## Summary

This PR fixes several Fast Marching Method distance initialization and propagation issues for vertex, edge, face, and curve sources.

## Details

### FMM source initialization

`FMMDistance()` now stores tentative distances for source-adjacent vertices when they are enqueued.

Previously, triangle updates could read `infinity` for vertices that had been queued from source geometry but had not yet been finalized. Recording the tentative distance at enqueue time ensures that adjacent triangle updates operate on the intended provisional source distances.

### Face-source distance correction

Face-source initialization now uses the correct opposite edge lengths in the barycentric squared-distance cross terms.

This PR also clamps tiny negative roundoff error before calling `sqrt()`. This prevents invalid source-to-vertex distances and avoids numerical NaNs caused by near-zero negative values.

### Source-branch shortcut prevention

The FMM priority queue now carries a source label with each candidate distance.

Triangle updates only combine distances from the same source branch unless the update crosses an explicit source support edge. This prevents unrelated source branches from being combined during propagation, which could otherwise create artificial shortcuts through the mesh.

Explicit source-base edges are recorded for:

* edge sources,
* face-source support edges, and
* signed curve segments.

This preserves valid source-local initialization while preventing unrelated branches from collapsing into incorrect shorter paths.

This was the most significant error addressed by the PR. The images below show the issue and the corrected behavior:

1. the underlying distance field,
2. the extracted isocontour before this fix, and
3. the extracted isocontour after this fix.

There is still some deviation along the diagonal in the post-fix result. That deviation appears to come from the marching triangles extraction step and the underlying distance field, rather than from the FMM propagation bug fixed here. I plan to address that separately in a follow-up PR.

<img width="2560" height="1403" alt="distance-field" src="https://github.com/user-attachments/assets/6febe1aa-cd14-4c0e-b2b3-0f06a30a8666" />

<img width="2560" height="1403" alt="pre-fix" src="https://github.com/user-attachments/assets/cf9d178a-6b7e-4f5c-bf51-5ede50fa40f3" />

<img width="2560" height="1403" alt="post-fix" src="https://github.com/user-attachments/assets/2647b49a-9cf5-44f8-8d32-e440f59d034e" />

## Impact

- Improves correctness of FMM geodesic distances for non-vertex sources.
- Prevents triangle updates from combining unrelated source branches.
- Avoids NaNs from small negative roundoff values in face-source initialization.
- Preserves the existing public API.